### PR TITLE
#5/content creator flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,61 +1,13 @@
-# 🚀 Getting started with Strapi
+## Running the system configuration migration
+In order to keep out Strapi backend in sync across different environments we are using the Config Sync plugin by auto-generating configuration files.
 
-Strapi comes with a full featured [Command Line Interface](https://docs.strapi.io/dev-docs/cli) (CLI) which lets you scaffold and manage your project in seconds.
+To make this easier see the script in the ```package.json```
 
-### `develop`
+### The flow:
+If you have change configuration or permission settings you need to run the command:
 
-Start your Strapi application with autoReload enabled. [Learn more](https://docs.strapi.io/dev-docs/cli#strapi-develop)
+``` npm run cs export ```
 
-```
-npm run develop
-# or
-yarn develop
-```
+After you merge new changes:
 
-### `start`
-
-Start your Strapi application with autoReload disabled. [Learn more](https://docs.strapi.io/dev-docs/cli#strapi-start)
-
-```
-npm run start
-# or
-yarn start
-```
-
-### `build`
-
-Build your admin panel. [Learn more](https://docs.strapi.io/dev-docs/cli#strapi-build)
-
-```
-npm run build
-# or
-yarn build
-```
-
-## ⚙️ Deployment
-
-Strapi gives you many possible deployment options for your project including [Strapi Cloud](https://cloud.strapi.io). Browse the [deployment section of the documentation](https://docs.strapi.io/dev-docs/deployment) to find the best solution for your use case.
-
-```
-yarn strapi deploy
-```
-
-## 📚 Learn more
-
-- [Resource center](https://strapi.io/resource-center) - Strapi resource center.
-- [Strapi documentation](https://docs.strapi.io) - Official Strapi documentation.
-- [Strapi tutorials](https://strapi.io/tutorials) - List of tutorials made by the core team and the community.
-- [Strapi blog](https://strapi.io/blog) - Official Strapi blog containing articles made by the Strapi team and the community.
-- [Changelog](https://strapi.io/changelog) - Find out about the Strapi product updates, new features and general improvements.
-
-Feel free to check out the [Strapi GitHub repository](https://github.com/strapi/strapi). Your feedback and contributions are welcome!
-
-## ✨ Community
-
-- [Discord](https://discord.strapi.io) - Come chat with the Strapi community including the core team.
-- [Forum](https://forum.strapi.io/) - Place to discuss, ask questions and find answers, show your Strapi project and get feedback or just talk with other Community members.
-- [Awesome Strapi](https://github.com/strapi/awesome-strapi) - A curated list of awesome things related to Strapi.
-
----
-
-<sub>🤫 Psst! [Strapi is hiring](https://strapi.io/careers).</sub>
+```npm run cs import``` 

--- a/config/admin.js
+++ b/config/admin.js
@@ -14,4 +14,7 @@ module.exports = ({ env }) => ({
     nps: env.bool('FLAG_NPS', true),
     promoteEE: env.bool('FLAG_PROMOTE_EE', true),
   },
+  watchIgnoreFiles: [
+    '**/config/sync/**',
+  ],
 });

--- a/config/sync/admin-role.strapi-author.json
+++ b/config/sync/admin-role.strapi-author.json
@@ -11,8 +11,7 @@
         "fields": [
           "is_quiet",
           "playlist",
-          "event_time",
-          "followed_artists"
+          "event_time"
         ]
       },
       "conditions": []
@@ -39,8 +38,7 @@
         "fields": [
           "is_quiet",
           "playlist",
-          "event_time",
-          "followed_artists"
+          "event_time"
         ]
       },
       "conditions": []
@@ -53,8 +51,7 @@
         "fields": [
           "is_quiet",
           "playlist",
-          "event_time",
-          "followed_artists"
+          "event_time"
         ]
       },
       "conditions": []
@@ -66,8 +63,7 @@
       "properties": {
         "fields": [
           "bio",
-          "projects",
-          "followers"
+          "projects"
         ]
       },
       "conditions": []
@@ -93,8 +89,7 @@
       "properties": {
         "fields": [
           "bio",
-          "projects",
-          "followers"
+          "projects"
         ]
       },
       "conditions": []
@@ -106,8 +101,7 @@
       "properties": {
         "fields": [
           "bio",
-          "projects",
-          "followers"
+          "projects"
         ]
       },
       "conditions": []

--- a/config/sync/admin-role.strapi-author.json
+++ b/config/sync/admin-role.strapi-author.json
@@ -1,7 +1,7 @@
 {
   "name": "Arebyte Admin",
   "code": "strapi-author",
-  "description": "Authors can manage the content they have created.",
+  "description": "Arebyte team to manage and moderate content",
   "permissions": [
     {
       "action": "plugin::content-manager.explorer.create",
@@ -12,8 +12,7 @@
           "is_quiet",
           "playlist",
           "event_time",
-          "followed_artists",
-          "user_id"
+          "followed_artists"
         ]
       },
       "conditions": []
@@ -41,8 +40,7 @@
           "is_quiet",
           "playlist",
           "event_time",
-          "followed_artists",
-          "user_id"
+          "followed_artists"
         ]
       },
       "conditions": []
@@ -56,8 +54,7 @@
           "is_quiet",
           "playlist",
           "event_time",
-          "followed_artists",
-          "user_id"
+          "followed_artists"
         ]
       },
       "conditions": []
@@ -70,8 +67,7 @@
         "fields": [
           "bio",
           "projects",
-          "followers",
-          "user_id"
+          "followers"
         ]
       },
       "conditions": []
@@ -98,8 +94,7 @@
         "fields": [
           "bio",
           "projects",
-          "followers",
-          "user_id"
+          "followers"
         ]
       },
       "conditions": []
@@ -112,8 +107,7 @@
         "fields": [
           "bio",
           "projects",
-          "followers",
-          "user_id"
+          "followers"
         ]
       },
       "conditions": []
@@ -124,11 +118,7 @@
       "subject": "api::event.event",
       "properties": {
         "fields": [
-          "title",
-          "pieces.title",
-          "pieces.media",
-          "pieces.description",
-          "project"
+          "title"
         ]
       },
       "conditions": []
@@ -153,11 +143,7 @@
       "subject": "api::event.event",
       "properties": {
         "fields": [
-          "title",
-          "pieces.title",
-          "pieces.media",
-          "pieces.description",
-          "project"
+          "title"
         ]
       },
       "conditions": []
@@ -168,11 +154,7 @@
       "subject": "api::event.event",
       "properties": {
         "fields": [
-          "title",
-          "pieces.title",
-          "pieces.media",
-          "pieces.description",
-          "project"
+          "title"
         ]
       },
       "conditions": []

--- a/config/sync/admin-role.strapi-author.json
+++ b/config/sync/admin-role.strapi-author.json
@@ -1,0 +1,353 @@
+{
+  "name": "Arebyte Admin",
+  "code": "strapi-author",
+  "description": "Authors can manage the content they have created.",
+  "permissions": [
+    {
+      "action": "plugin::content-manager.explorer.create",
+      "actionParameters": {},
+      "subject": "api::audience-member.audience-member",
+      "properties": {
+        "fields": [
+          "is_quiet",
+          "playlist",
+          "event_time",
+          "followed_artists",
+          "user_id"
+        ]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.delete",
+      "actionParameters": {},
+      "subject": "api::audience-member.audience-member",
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.publish",
+      "actionParameters": {},
+      "subject": "api::audience-member.audience-member",
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.read",
+      "actionParameters": {},
+      "subject": "api::audience-member.audience-member",
+      "properties": {
+        "fields": [
+          "is_quiet",
+          "playlist",
+          "event_time",
+          "followed_artists",
+          "user_id"
+        ]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.update",
+      "actionParameters": {},
+      "subject": "api::audience-member.audience-member",
+      "properties": {
+        "fields": [
+          "is_quiet",
+          "playlist",
+          "event_time",
+          "followed_artists",
+          "user_id"
+        ]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.create",
+      "actionParameters": {},
+      "subject": "api::content-creator.content-creator",
+      "properties": {
+        "fields": [
+          "bio",
+          "projects",
+          "followers",
+          "user_id"
+        ]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.delete",
+      "actionParameters": {},
+      "subject": "api::content-creator.content-creator",
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.publish",
+      "actionParameters": {},
+      "subject": "api::content-creator.content-creator",
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.read",
+      "actionParameters": {},
+      "subject": "api::content-creator.content-creator",
+      "properties": {
+        "fields": [
+          "bio",
+          "projects",
+          "followers",
+          "user_id"
+        ]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.update",
+      "actionParameters": {},
+      "subject": "api::content-creator.content-creator",
+      "properties": {
+        "fields": [
+          "bio",
+          "projects",
+          "followers",
+          "user_id"
+        ]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.create",
+      "actionParameters": {},
+      "subject": "api::event.event",
+      "properties": {
+        "fields": [
+          "title",
+          "pieces.title",
+          "pieces.media",
+          "pieces.description",
+          "project"
+        ]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.delete",
+      "actionParameters": {},
+      "subject": "api::event.event",
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.publish",
+      "actionParameters": {},
+      "subject": "api::event.event",
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.read",
+      "actionParameters": {},
+      "subject": "api::event.event",
+      "properties": {
+        "fields": [
+          "title",
+          "pieces.title",
+          "pieces.media",
+          "pieces.description",
+          "project"
+        ]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.update",
+      "actionParameters": {},
+      "subject": "api::event.event",
+      "properties": {
+        "fields": [
+          "title",
+          "pieces.title",
+          "pieces.media",
+          "pieces.description",
+          "project"
+        ]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.create",
+      "actionParameters": {},
+      "subject": "api::project.project",
+      "properties": {
+        "fields": [
+          "title",
+          "description",
+          "launch_date",
+          "cover_image",
+          "content_creator",
+          "events"
+        ]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.delete",
+      "actionParameters": {},
+      "subject": "api::project.project",
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.publish",
+      "actionParameters": {},
+      "subject": "api::project.project",
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.read",
+      "actionParameters": {},
+      "subject": "api::project.project",
+      "properties": {
+        "fields": [
+          "title",
+          "description",
+          "launch_date",
+          "cover_image",
+          "content_creator",
+          "events"
+        ]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.update",
+      "actionParameters": {},
+      "subject": "api::project.project",
+      "properties": {
+        "fields": [
+          "title",
+          "description",
+          "launch_date",
+          "cover_image",
+          "content_creator",
+          "events"
+        ]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.create",
+      "actionParameters": {},
+      "subject": "plugin::users-permissions.user",
+      "properties": {
+        "fields": [
+          "username",
+          "email",
+          "provider",
+          "password",
+          "resetPasswordToken",
+          "confirmationToken",
+          "confirmed",
+          "blocked",
+          "role"
+        ]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.delete",
+      "actionParameters": {},
+      "subject": "plugin::users-permissions.user",
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.read",
+      "actionParameters": {},
+      "subject": "plugin::users-permissions.user",
+      "properties": {
+        "fields": [
+          "username",
+          "email",
+          "provider",
+          "password",
+          "resetPasswordToken",
+          "confirmationToken",
+          "confirmed",
+          "blocked",
+          "role"
+        ]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.update",
+      "actionParameters": {},
+      "subject": "plugin::users-permissions.user",
+      "properties": {
+        "fields": [
+          "username",
+          "email",
+          "provider",
+          "password",
+          "resetPasswordToken",
+          "confirmationToken",
+          "confirmed",
+          "blocked",
+          "role"
+        ]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::upload.assets.copy-link",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::upload.assets.create",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::upload.assets.download",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::upload.assets.update",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": [
+        "admin::is-creator"
+      ]
+    },
+    {
+      "action": "plugin::upload.configure-view",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::upload.read",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": [
+        "admin::is-creator"
+      ]
+    }
+  ]
+}

--- a/config/sync/admin-role.strapi-editor.json
+++ b/config/sync/admin-role.strapi-editor.json
@@ -11,8 +11,7 @@
         "fields": [
           "bio",
           "projects",
-          "followers",
-          "user_id"
+          "followers"
         ]
       },
       "conditions": [
@@ -46,7 +45,7 @@
           "bio",
           "projects",
           "followers",
-          "user_id"
+          "admin_user"
         ]
       },
       "conditions": [
@@ -62,7 +61,7 @@
           "bio",
           "projects",
           "followers",
-          "user_id"
+          "admin_user"
         ]
       },
       "conditions": [
@@ -76,10 +75,9 @@
       "properties": {
         "fields": [
           "title",
-          "pieces.title",
-          "pieces.media",
-          "pieces.description",
-          "project"
+          "in_project",
+          "pop_ups",
+          "event_description"
         ]
       },
       "conditions": [
@@ -111,13 +109,13 @@
       "properties": {
         "fields": [
           "title",
-          "pieces.title",
-          "pieces.media",
-          "pieces.description",
-          "project"
+          "in_project",
+          "pop_ups",
+          "event_description"
         ]
       },
       "conditions": [
+        "admin::is-creator",
         "admin::has-same-role-as-creator"
       ]
     },
@@ -128,10 +126,79 @@
       "properties": {
         "fields": [
           "title",
-          "pieces.title",
-          "pieces.media",
-          "pieces.description",
-          "project"
+          "in_project",
+          "pop_ups",
+          "event_description"
+        ]
+      },
+      "conditions": [
+        "admin::is-creator"
+      ]
+    },
+    {
+      "action": "plugin::content-manager.explorer.create",
+      "actionParameters": {},
+      "subject": "api::pop-up.pop-up",
+      "properties": {
+        "fields": [
+          "title",
+          "media",
+          "description",
+          "popup_size",
+          "popup_position"
+        ]
+      },
+      "conditions": [
+        "admin::is-creator"
+      ]
+    },
+    {
+      "action": "plugin::content-manager.explorer.delete",
+      "actionParameters": {},
+      "subject": "api::pop-up.pop-up",
+      "properties": {},
+      "conditions": [
+        "admin::is-creator"
+      ]
+    },
+    {
+      "action": "plugin::content-manager.explorer.publish",
+      "actionParameters": {},
+      "subject": "api::pop-up.pop-up",
+      "properties": {},
+      "conditions": [
+        "admin::is-creator"
+      ]
+    },
+    {
+      "action": "plugin::content-manager.explorer.read",
+      "actionParameters": {},
+      "subject": "api::pop-up.pop-up",
+      "properties": {
+        "fields": [
+          "title",
+          "media",
+          "description",
+          "popup_size",
+          "popup_position"
+        ]
+      },
+      "conditions": [
+        "admin::is-creator",
+        "admin::has-same-role-as-creator"
+      ]
+    },
+    {
+      "action": "plugin::content-manager.explorer.update",
+      "actionParameters": {},
+      "subject": "api::pop-up.pop-up",
+      "properties": {
+        "fields": [
+          "title",
+          "media",
+          "description",
+          "popup_size",
+          "popup_position"
         ]
       },
       "conditions": [
@@ -204,6 +271,69 @@
           "cover_image",
           "content_creator",
           "events"
+        ]
+      },
+      "conditions": [
+        "admin::is-creator"
+      ]
+    },
+    {
+      "action": "plugin::content-manager.explorer.create",
+      "actionParameters": {},
+      "subject": "plugin::users-permissions.user",
+      "properties": {
+        "fields": [
+          "username",
+          "email",
+          "provider",
+          "password",
+          "resetPasswordToken",
+          "confirmationToken",
+          "confirmed",
+          "blocked",
+          "role"
+        ]
+      },
+      "conditions": [
+        "admin::is-creator"
+      ]
+    },
+    {
+      "action": "plugin::content-manager.explorer.delete",
+      "actionParameters": {},
+      "subject": "plugin::users-permissions.user",
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.read",
+      "actionParameters": {},
+      "subject": "plugin::users-permissions.user",
+      "properties": {
+        "fields": [
+          "username",
+          "email"
+        ]
+      },
+      "conditions": [
+        "admin::is-creator"
+      ]
+    },
+    {
+      "action": "plugin::content-manager.explorer.update",
+      "actionParameters": {},
+      "subject": "plugin::users-permissions.user",
+      "properties": {
+        "fields": [
+          "username",
+          "email",
+          "provider",
+          "password",
+          "resetPasswordToken",
+          "confirmationToken",
+          "confirmed",
+          "blocked",
+          "role"
         ]
       },
       "conditions": [

--- a/config/sync/admin-role.strapi-editor.json
+++ b/config/sync/admin-role.strapi-editor.json
@@ -11,7 +11,7 @@
         "fields": [
           "bio",
           "projects",
-          "followers"
+          "artist_name"
         ]
       },
       "conditions": [
@@ -44,12 +44,11 @@
         "fields": [
           "bio",
           "projects",
-          "followers",
-          "admin_user"
+          "artist_name"
         ]
       },
       "conditions": [
-        "admin::has-same-role-as-creator"
+        "admin::is-creator"
       ]
     },
     {
@@ -60,8 +59,7 @@
         "fields": [
           "bio",
           "projects",
-          "followers",
-          "admin_user"
+          "artist_name"
         ]
       },
       "conditions": [
@@ -115,8 +113,7 @@
         ]
       },
       "conditions": [
-        "admin::is-creator",
-        "admin::has-same-role-as-creator"
+        "admin::is-creator"
       ]
     },
     {
@@ -184,8 +181,7 @@
         ]
       },
       "conditions": [
-        "admin::is-creator",
-        "admin::has-same-role-as-creator"
+        "admin::is-creator"
       ]
     },
     {
@@ -256,7 +252,7 @@
         ]
       },
       "conditions": [
-        "admin::has-same-role-as-creator"
+        "admin::is-creator"
       ]
     },
     {
@@ -271,69 +267,6 @@
           "cover_image",
           "content_creator",
           "events"
-        ]
-      },
-      "conditions": [
-        "admin::is-creator"
-      ]
-    },
-    {
-      "action": "plugin::content-manager.explorer.create",
-      "actionParameters": {},
-      "subject": "plugin::users-permissions.user",
-      "properties": {
-        "fields": [
-          "username",
-          "email",
-          "provider",
-          "password",
-          "resetPasswordToken",
-          "confirmationToken",
-          "confirmed",
-          "blocked",
-          "role"
-        ]
-      },
-      "conditions": [
-        "admin::is-creator"
-      ]
-    },
-    {
-      "action": "plugin::content-manager.explorer.delete",
-      "actionParameters": {},
-      "subject": "plugin::users-permissions.user",
-      "properties": {},
-      "conditions": []
-    },
-    {
-      "action": "plugin::content-manager.explorer.read",
-      "actionParameters": {},
-      "subject": "plugin::users-permissions.user",
-      "properties": {
-        "fields": [
-          "username",
-          "email"
-        ]
-      },
-      "conditions": [
-        "admin::is-creator"
-      ]
-    },
-    {
-      "action": "plugin::content-manager.explorer.update",
-      "actionParameters": {},
-      "subject": "plugin::users-permissions.user",
-      "properties": {
-        "fields": [
-          "username",
-          "email",
-          "provider",
-          "password",
-          "resetPasswordToken",
-          "confirmationToken",
-          "confirmed",
-          "blocked",
-          "role"
         ]
       },
       "conditions": [

--- a/config/sync/admin-role.strapi-editor.json
+++ b/config/sync/admin-role.strapi-editor.json
@@ -1,0 +1,256 @@
+{
+  "name": "Content Creator",
+  "code": "strapi-editor",
+  "description": "Editors can manage and publish contents including those of other users.",
+  "permissions": [
+    {
+      "action": "plugin::content-manager.explorer.create",
+      "actionParameters": {},
+      "subject": "api::content-creator.content-creator",
+      "properties": {
+        "fields": [
+          "bio",
+          "projects",
+          "followers",
+          "user_id"
+        ]
+      },
+      "conditions": [
+        "admin::is-creator"
+      ]
+    },
+    {
+      "action": "plugin::content-manager.explorer.delete",
+      "actionParameters": {},
+      "subject": "api::content-creator.content-creator",
+      "properties": {},
+      "conditions": [
+        "admin::is-creator"
+      ]
+    },
+    {
+      "action": "plugin::content-manager.explorer.publish",
+      "actionParameters": {},
+      "subject": "api::content-creator.content-creator",
+      "properties": {},
+      "conditions": [
+        "admin::is-creator"
+      ]
+    },
+    {
+      "action": "plugin::content-manager.explorer.read",
+      "actionParameters": {},
+      "subject": "api::content-creator.content-creator",
+      "properties": {
+        "fields": [
+          "bio",
+          "projects",
+          "followers",
+          "user_id"
+        ]
+      },
+      "conditions": [
+        "admin::has-same-role-as-creator"
+      ]
+    },
+    {
+      "action": "plugin::content-manager.explorer.update",
+      "actionParameters": {},
+      "subject": "api::content-creator.content-creator",
+      "properties": {
+        "fields": [
+          "bio",
+          "projects",
+          "followers",
+          "user_id"
+        ]
+      },
+      "conditions": [
+        "admin::is-creator"
+      ]
+    },
+    {
+      "action": "plugin::content-manager.explorer.create",
+      "actionParameters": {},
+      "subject": "api::event.event",
+      "properties": {
+        "fields": [
+          "title",
+          "pieces.title",
+          "pieces.media",
+          "pieces.description",
+          "project"
+        ]
+      },
+      "conditions": [
+        "admin::is-creator"
+      ]
+    },
+    {
+      "action": "plugin::content-manager.explorer.delete",
+      "actionParameters": {},
+      "subject": "api::event.event",
+      "properties": {},
+      "conditions": [
+        "admin::is-creator"
+      ]
+    },
+    {
+      "action": "plugin::content-manager.explorer.publish",
+      "actionParameters": {},
+      "subject": "api::event.event",
+      "properties": {},
+      "conditions": [
+        "admin::is-creator"
+      ]
+    },
+    {
+      "action": "plugin::content-manager.explorer.read",
+      "actionParameters": {},
+      "subject": "api::event.event",
+      "properties": {
+        "fields": [
+          "title",
+          "pieces.title",
+          "pieces.media",
+          "pieces.description",
+          "project"
+        ]
+      },
+      "conditions": [
+        "admin::has-same-role-as-creator"
+      ]
+    },
+    {
+      "action": "plugin::content-manager.explorer.update",
+      "actionParameters": {},
+      "subject": "api::event.event",
+      "properties": {
+        "fields": [
+          "title",
+          "pieces.title",
+          "pieces.media",
+          "pieces.description",
+          "project"
+        ]
+      },
+      "conditions": [
+        "admin::is-creator"
+      ]
+    },
+    {
+      "action": "plugin::content-manager.explorer.create",
+      "actionParameters": {},
+      "subject": "api::project.project",
+      "properties": {
+        "fields": [
+          "title",
+          "description",
+          "launch_date",
+          "cover_image",
+          "content_creator",
+          "events"
+        ]
+      },
+      "conditions": [
+        "admin::is-creator"
+      ]
+    },
+    {
+      "action": "plugin::content-manager.explorer.delete",
+      "actionParameters": {},
+      "subject": "api::project.project",
+      "properties": {},
+      "conditions": [
+        "admin::is-creator"
+      ]
+    },
+    {
+      "action": "plugin::content-manager.explorer.publish",
+      "actionParameters": {},
+      "subject": "api::project.project",
+      "properties": {},
+      "conditions": [
+        "admin::is-creator"
+      ]
+    },
+    {
+      "action": "plugin::content-manager.explorer.read",
+      "actionParameters": {},
+      "subject": "api::project.project",
+      "properties": {
+        "fields": [
+          "title",
+          "description",
+          "launch_date",
+          "cover_image",
+          "content_creator",
+          "events"
+        ]
+      },
+      "conditions": [
+        "admin::has-same-role-as-creator"
+      ]
+    },
+    {
+      "action": "plugin::content-manager.explorer.update",
+      "actionParameters": {},
+      "subject": "api::project.project",
+      "properties": {
+        "fields": [
+          "title",
+          "description",
+          "launch_date",
+          "cover_image",
+          "content_creator",
+          "events"
+        ]
+      },
+      "conditions": [
+        "admin::is-creator"
+      ]
+    },
+    {
+      "action": "plugin::upload.assets.copy-link",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::upload.assets.create",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::upload.assets.download",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::upload.assets.update",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::upload.configure-view",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::upload.read",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    }
+  ]
+}

--- a/config/sync/admin-role.strapi-super-admin.json
+++ b/config/sync/admin-role.strapi-super-admin.json
@@ -12,7 +12,6 @@
           "is_quiet",
           "playlist",
           "event_time",
-          "followed_artists",
           "user_id"
         ]
       },
@@ -41,7 +40,6 @@
           "is_quiet",
           "playlist",
           "event_time",
-          "followed_artists",
           "user_id"
         ]
       },
@@ -56,7 +54,6 @@
           "is_quiet",
           "playlist",
           "event_time",
-          "followed_artists",
           "user_id"
         ]
       },
@@ -70,8 +67,7 @@
         "fields": [
           "bio",
           "projects",
-          "followers",
-          "admin_user"
+          "artist_name"
         ]
       },
       "conditions": []
@@ -98,8 +94,7 @@
         "fields": [
           "bio",
           "projects",
-          "followers",
-          "admin_user"
+          "artist_name"
         ]
       },
       "conditions": []
@@ -112,8 +107,7 @@
         "fields": [
           "bio",
           "projects",
-          "followers",
-          "admin_user"
+          "artist_name"
         ]
       },
       "conditions": []

--- a/config/sync/admin-role.strapi-super-admin.json
+++ b/config/sync/admin-role.strapi-super-admin.json
@@ -1,0 +1,692 @@
+{
+  "name": "Super Admin",
+  "code": "strapi-super-admin",
+  "description": "Super Admins can access and manage all features and settings.",
+  "permissions": [
+    {
+      "action": "plugin::content-manager.explorer.create",
+      "actionParameters": {},
+      "subject": "api::audience-member.audience-member",
+      "properties": {
+        "fields": [
+          "is_quiet",
+          "playlist",
+          "event_time",
+          "followed_artists",
+          "user_id"
+        ]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.delete",
+      "actionParameters": {},
+      "subject": "api::audience-member.audience-member",
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.publish",
+      "actionParameters": {},
+      "subject": "api::audience-member.audience-member",
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.read",
+      "actionParameters": {},
+      "subject": "api::audience-member.audience-member",
+      "properties": {
+        "fields": [
+          "is_quiet",
+          "playlist",
+          "event_time",
+          "followed_artists",
+          "user_id"
+        ]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.update",
+      "actionParameters": {},
+      "subject": "api::audience-member.audience-member",
+      "properties": {
+        "fields": [
+          "is_quiet",
+          "playlist",
+          "event_time",
+          "followed_artists",
+          "user_id"
+        ]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.create",
+      "actionParameters": {},
+      "subject": "api::content-creator.content-creator",
+      "properties": {
+        "fields": [
+          "bio",
+          "projects",
+          "followers",
+          "user_id"
+        ]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.delete",
+      "actionParameters": {},
+      "subject": "api::content-creator.content-creator",
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.publish",
+      "actionParameters": {},
+      "subject": "api::content-creator.content-creator",
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.read",
+      "actionParameters": {},
+      "subject": "api::content-creator.content-creator",
+      "properties": {
+        "fields": [
+          "bio",
+          "projects",
+          "followers",
+          "user_id"
+        ]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.update",
+      "actionParameters": {},
+      "subject": "api::content-creator.content-creator",
+      "properties": {
+        "fields": [
+          "bio",
+          "projects",
+          "followers",
+          "user_id"
+        ]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.create",
+      "actionParameters": {},
+      "subject": "api::event.event",
+      "properties": {
+        "fields": [
+          "title",
+          "pieces.title",
+          "pieces.media",
+          "pieces.description",
+          "project"
+        ]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.delete",
+      "actionParameters": {},
+      "subject": "api::event.event",
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.publish",
+      "actionParameters": {},
+      "subject": "api::event.event",
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.read",
+      "actionParameters": {},
+      "subject": "api::event.event",
+      "properties": {
+        "fields": [
+          "title",
+          "pieces.title",
+          "pieces.media",
+          "pieces.description",
+          "project"
+        ]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.update",
+      "actionParameters": {},
+      "subject": "api::event.event",
+      "properties": {
+        "fields": [
+          "title",
+          "pieces.title",
+          "pieces.media",
+          "pieces.description",
+          "project"
+        ]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.create",
+      "actionParameters": {},
+      "subject": "api::project.project",
+      "properties": {
+        "fields": [
+          "title",
+          "description",
+          "launch_date",
+          "cover_image",
+          "content_creator",
+          "events"
+        ]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.delete",
+      "actionParameters": {},
+      "subject": "api::project.project",
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.publish",
+      "actionParameters": {},
+      "subject": "api::project.project",
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.read",
+      "actionParameters": {},
+      "subject": "api::project.project",
+      "properties": {
+        "fields": [
+          "title",
+          "description",
+          "launch_date",
+          "cover_image",
+          "content_creator",
+          "events"
+        ]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.update",
+      "actionParameters": {},
+      "subject": "api::project.project",
+      "properties": {
+        "fields": [
+          "title",
+          "description",
+          "launch_date",
+          "cover_image",
+          "content_creator",
+          "events"
+        ]
+      },
+      "conditions": []
+    },
+    {
+      "action": "admin::api-tokens.access",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "admin::api-tokens.create",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "admin::api-tokens.delete",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "admin::api-tokens.read",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "admin::api-tokens.regenerate",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "admin::api-tokens.update",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "admin::marketplace.read",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "admin::project-settings.read",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "admin::project-settings.update",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "admin::roles.create",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "admin::roles.delete",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "admin::roles.read",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "admin::roles.update",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "admin::transfer.tokens.access",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "admin::transfer.tokens.create",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "admin::transfer.tokens.delete",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "admin::transfer.tokens.read",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "admin::transfer.tokens.regenerate",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "admin::transfer.tokens.update",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "admin::users.create",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "admin::users.delete",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "admin::users.read",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "admin::users.update",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "admin::webhooks.create",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "admin::webhooks.delete",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "admin::webhooks.read",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "admin::webhooks.update",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::config-sync.menu-link",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::config-sync.settings.read",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.collection-types.configure-view",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.components.configure-layout",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.create",
+      "actionParameters": {},
+      "subject": "plugin::users-permissions.user",
+      "properties": {
+        "fields": [
+          "username",
+          "email",
+          "provider",
+          "password",
+          "resetPasswordToken",
+          "confirmationToken",
+          "confirmed",
+          "blocked",
+          "role"
+        ]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.delete",
+      "actionParameters": {},
+      "subject": "plugin::users-permissions.user",
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.read",
+      "actionParameters": {},
+      "subject": "plugin::users-permissions.user",
+      "properties": {
+        "fields": [
+          "username",
+          "email",
+          "provider",
+          "password",
+          "resetPasswordToken",
+          "confirmationToken",
+          "confirmed",
+          "blocked",
+          "role"
+        ]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.update",
+      "actionParameters": {},
+      "subject": "plugin::users-permissions.user",
+      "properties": {
+        "fields": [
+          "username",
+          "email",
+          "provider",
+          "password",
+          "resetPasswordToken",
+          "confirmationToken",
+          "confirmed",
+          "blocked",
+          "role"
+        ]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.single-types.configure-view",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-type-builder.read",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::email.settings.read",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::i18n.locale.create",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::i18n.locale.delete",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::i18n.locale.read",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::i18n.locale.update",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::upload.assets.copy-link",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::upload.assets.create",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::upload.assets.download",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::upload.assets.update",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::upload.configure-view",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::upload.read",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::upload.settings.read",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::users-permissions.advanced-settings.read",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::users-permissions.advanced-settings.update",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::users-permissions.email-templates.read",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::users-permissions.email-templates.update",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::users-permissions.providers.read",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::users-permissions.providers.update",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::users-permissions.roles.create",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::users-permissions.roles.delete",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::users-permissions.roles.read",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::users-permissions.roles.update",
+      "actionParameters": {},
+      "subject": null,
+      "properties": {},
+      "conditions": []
+    }
+  ]
+}

--- a/config/sync/admin-role.strapi-super-admin.json
+++ b/config/sync/admin-role.strapi-super-admin.json
@@ -71,7 +71,7 @@
           "bio",
           "projects",
           "followers",
-          "user_id"
+          "admin_user"
         ]
       },
       "conditions": []
@@ -99,7 +99,7 @@
           "bio",
           "projects",
           "followers",
-          "user_id"
+          "admin_user"
         ]
       },
       "conditions": []
@@ -113,7 +113,7 @@
           "bio",
           "projects",
           "followers",
-          "user_id"
+          "admin_user"
         ]
       },
       "conditions": []
@@ -125,10 +125,9 @@
       "properties": {
         "fields": [
           "title",
-          "pieces.title",
-          "pieces.media",
-          "pieces.description",
-          "project"
+          "in_project",
+          "pop_ups",
+          "event_description"
         ]
       },
       "conditions": []
@@ -154,10 +153,9 @@
       "properties": {
         "fields": [
           "title",
-          "pieces.title",
-          "pieces.media",
-          "pieces.description",
-          "project"
+          "in_project",
+          "pop_ups",
+          "event_description"
         ]
       },
       "conditions": []
@@ -169,10 +167,68 @@
       "properties": {
         "fields": [
           "title",
-          "pieces.title",
-          "pieces.media",
-          "pieces.description",
-          "project"
+          "in_project",
+          "pop_ups",
+          "event_description"
+        ]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.create",
+      "actionParameters": {},
+      "subject": "api::pop-up.pop-up",
+      "properties": {
+        "fields": [
+          "title",
+          "media",
+          "description",
+          "popup_size",
+          "popup_position"
+        ]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.delete",
+      "actionParameters": {},
+      "subject": "api::pop-up.pop-up",
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.publish",
+      "actionParameters": {},
+      "subject": "api::pop-up.pop-up",
+      "properties": {},
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.read",
+      "actionParameters": {},
+      "subject": "api::pop-up.pop-up",
+      "properties": {
+        "fields": [
+          "title",
+          "media",
+          "description",
+          "popup_size",
+          "popup_position"
+        ]
+      },
+      "conditions": []
+    },
+    {
+      "action": "plugin::content-manager.explorer.update",
+      "actionParameters": {},
+      "subject": "api::pop-up.pop-up",
+      "properties": {
+        "fields": [
+          "title",
+          "media",
+          "description",
+          "popup_size",
+          "popup_position"
         ]
       },
       "conditions": []

--- a/config/sync/core-store.core_admin_auth.json
+++ b/config/sync/core-store.core_admin_auth.json
@@ -1,0 +1,13 @@
+{
+  "key": "core_admin_auth",
+  "value": {
+    "providers": {
+      "autoRegister": false,
+      "defaultRole": null,
+      "ssoLockedRoles": null
+    }
+  },
+  "type": "object",
+  "environment": null,
+  "tag": null
+}

--- a/config/sync/core-store.plugin_content_manager_configuration_components##piece.piece.json
+++ b/config/sync/core-store.plugin_content_manager_configuration_components##piece.piece.json
@@ -1,0 +1,96 @@
+{
+  "key": "plugin_content_manager_configuration_components::piece.piece",
+  "value": {
+    "settings": {
+      "bulkable": true,
+      "filterable": true,
+      "searchable": true,
+      "pageSize": 10,
+      "mainField": "title",
+      "defaultSortBy": "title",
+      "defaultSortOrder": "ASC"
+    },
+    "metadatas": {
+      "id": {
+        "edit": {},
+        "list": {
+          "label": "id",
+          "searchable": false,
+          "sortable": false
+        }
+      },
+      "title": {
+        "edit": {
+          "label": "title",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "title",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "media": {
+        "edit": {
+          "label": "media",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "media",
+          "searchable": false,
+          "sortable": false
+        }
+      },
+      "description": {
+        "edit": {
+          "label": "description",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "description",
+          "searchable": false,
+          "sortable": false
+        }
+      }
+    },
+    "layouts": {
+      "list": [
+        "id",
+        "title",
+        "media"
+      ],
+      "edit": [
+        [
+          {
+            "name": "title",
+            "size": 6
+          },
+          {
+            "name": "media",
+            "size": 6
+          }
+        ],
+        [
+          {
+            "name": "description",
+            "size": 12
+          }
+        ]
+      ]
+    },
+    "uid": "piece.piece",
+    "isComponent": true
+  },
+  "type": "object",
+  "environment": null,
+  "tag": null
+}

--- a/config/sync/core-store.plugin_content_manager_configuration_content_types##admin##api-token-permission.json
+++ b/config/sync/core-store.plugin_content_manager_configuration_content_types##admin##api-token-permission.json
@@ -1,0 +1,135 @@
+{
+  "key": "plugin_content_manager_configuration_content_types::admin::api-token-permission",
+  "value": {
+    "settings": {
+      "bulkable": true,
+      "filterable": true,
+      "searchable": true,
+      "pageSize": 10,
+      "mainField": "action",
+      "defaultSortBy": "action",
+      "defaultSortOrder": "ASC"
+    },
+    "metadatas": {
+      "id": {
+        "edit": {},
+        "list": {
+          "label": "id",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "action": {
+        "edit": {
+          "label": "action",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "action",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "token": {
+        "edit": {
+          "label": "token",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true,
+          "mainField": "name"
+        },
+        "list": {
+          "label": "token",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "createdAt": {
+        "edit": {
+          "label": "createdAt",
+          "description": "",
+          "placeholder": "",
+          "visible": false,
+          "editable": true
+        },
+        "list": {
+          "label": "createdAt",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "updatedAt": {
+        "edit": {
+          "label": "updatedAt",
+          "description": "",
+          "placeholder": "",
+          "visible": false,
+          "editable": true
+        },
+        "list": {
+          "label": "updatedAt",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "createdBy": {
+        "edit": {
+          "label": "createdBy",
+          "description": "",
+          "placeholder": "",
+          "visible": false,
+          "editable": true,
+          "mainField": "firstname"
+        },
+        "list": {
+          "label": "createdBy",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "updatedBy": {
+        "edit": {
+          "label": "updatedBy",
+          "description": "",
+          "placeholder": "",
+          "visible": false,
+          "editable": true,
+          "mainField": "firstname"
+        },
+        "list": {
+          "label": "updatedBy",
+          "searchable": true,
+          "sortable": true
+        }
+      }
+    },
+    "layouts": {
+      "list": [
+        "id",
+        "action",
+        "token",
+        "createdAt"
+      ],
+      "edit": [
+        [
+          {
+            "name": "action",
+            "size": 6
+          },
+          {
+            "name": "token",
+            "size": 6
+          }
+        ]
+      ]
+    },
+    "uid": "admin::api-token-permission"
+  },
+  "type": "object",
+  "environment": null,
+  "tag": null
+}

--- a/config/sync/core-store.plugin_content_manager_configuration_content_types##admin##api-token.json
+++ b/config/sync/core-store.plugin_content_manager_configuration_content_types##admin##api-token.json
@@ -1,0 +1,249 @@
+{
+  "key": "plugin_content_manager_configuration_content_types::admin::api-token",
+  "value": {
+    "settings": {
+      "bulkable": true,
+      "filterable": true,
+      "searchable": true,
+      "pageSize": 10,
+      "mainField": "name",
+      "defaultSortBy": "name",
+      "defaultSortOrder": "ASC"
+    },
+    "metadatas": {
+      "id": {
+        "edit": {},
+        "list": {
+          "label": "id",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "name": {
+        "edit": {
+          "label": "name",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "name",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "description": {
+        "edit": {
+          "label": "description",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "description",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "type": {
+        "edit": {
+          "label": "type",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "type",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "accessKey": {
+        "edit": {
+          "label": "accessKey",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "accessKey",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "lastUsedAt": {
+        "edit": {
+          "label": "lastUsedAt",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "lastUsedAt",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "permissions": {
+        "edit": {
+          "label": "permissions",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true,
+          "mainField": "action"
+        },
+        "list": {
+          "label": "permissions",
+          "searchable": false,
+          "sortable": false
+        }
+      },
+      "expiresAt": {
+        "edit": {
+          "label": "expiresAt",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "expiresAt",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "lifespan": {
+        "edit": {
+          "label": "lifespan",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "lifespan",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "createdAt": {
+        "edit": {
+          "label": "createdAt",
+          "description": "",
+          "placeholder": "",
+          "visible": false,
+          "editable": true
+        },
+        "list": {
+          "label": "createdAt",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "updatedAt": {
+        "edit": {
+          "label": "updatedAt",
+          "description": "",
+          "placeholder": "",
+          "visible": false,
+          "editable": true
+        },
+        "list": {
+          "label": "updatedAt",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "createdBy": {
+        "edit": {
+          "label": "createdBy",
+          "description": "",
+          "placeholder": "",
+          "visible": false,
+          "editable": true,
+          "mainField": "firstname"
+        },
+        "list": {
+          "label": "createdBy",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "updatedBy": {
+        "edit": {
+          "label": "updatedBy",
+          "description": "",
+          "placeholder": "",
+          "visible": false,
+          "editable": true,
+          "mainField": "firstname"
+        },
+        "list": {
+          "label": "updatedBy",
+          "searchable": true,
+          "sortable": true
+        }
+      }
+    },
+    "layouts": {
+      "list": [
+        "id",
+        "name",
+        "description",
+        "type"
+      ],
+      "edit": [
+        [
+          {
+            "name": "name",
+            "size": 6
+          },
+          {
+            "name": "description",
+            "size": 6
+          }
+        ],
+        [
+          {
+            "name": "type",
+            "size": 6
+          },
+          {
+            "name": "accessKey",
+            "size": 6
+          }
+        ],
+        [
+          {
+            "name": "lastUsedAt",
+            "size": 6
+          },
+          {
+            "name": "permissions",
+            "size": 6
+          }
+        ],
+        [
+          {
+            "name": "expiresAt",
+            "size": 6
+          },
+          {
+            "name": "lifespan",
+            "size": 4
+          }
+        ]
+      ]
+    },
+    "uid": "admin::api-token"
+  },
+  "type": "object",
+  "environment": null,
+  "tag": null
+}

--- a/config/sync/core-store.plugin_content_manager_configuration_content_types##admin##permission.json
+++ b/config/sync/core-store.plugin_content_manager_configuration_content_types##admin##permission.json
@@ -1,0 +1,217 @@
+{
+  "key": "plugin_content_manager_configuration_content_types::admin::permission",
+  "value": {
+    "settings": {
+      "bulkable": true,
+      "filterable": true,
+      "searchable": true,
+      "pageSize": 10,
+      "mainField": "action",
+      "defaultSortBy": "action",
+      "defaultSortOrder": "ASC"
+    },
+    "metadatas": {
+      "id": {
+        "edit": {},
+        "list": {
+          "label": "id",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "action": {
+        "edit": {
+          "label": "action",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "action",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "actionParameters": {
+        "edit": {
+          "label": "actionParameters",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "actionParameters",
+          "searchable": false,
+          "sortable": false
+        }
+      },
+      "subject": {
+        "edit": {
+          "label": "subject",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "subject",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "properties": {
+        "edit": {
+          "label": "properties",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "properties",
+          "searchable": false,
+          "sortable": false
+        }
+      },
+      "conditions": {
+        "edit": {
+          "label": "conditions",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "conditions",
+          "searchable": false,
+          "sortable": false
+        }
+      },
+      "role": {
+        "edit": {
+          "label": "role",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true,
+          "mainField": "name"
+        },
+        "list": {
+          "label": "role",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "createdAt": {
+        "edit": {
+          "label": "createdAt",
+          "description": "",
+          "placeholder": "",
+          "visible": false,
+          "editable": true
+        },
+        "list": {
+          "label": "createdAt",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "updatedAt": {
+        "edit": {
+          "label": "updatedAt",
+          "description": "",
+          "placeholder": "",
+          "visible": false,
+          "editable": true
+        },
+        "list": {
+          "label": "updatedAt",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "createdBy": {
+        "edit": {
+          "label": "createdBy",
+          "description": "",
+          "placeholder": "",
+          "visible": false,
+          "editable": true,
+          "mainField": "firstname"
+        },
+        "list": {
+          "label": "createdBy",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "updatedBy": {
+        "edit": {
+          "label": "updatedBy",
+          "description": "",
+          "placeholder": "",
+          "visible": false,
+          "editable": true,
+          "mainField": "firstname"
+        },
+        "list": {
+          "label": "updatedBy",
+          "searchable": true,
+          "sortable": true
+        }
+      }
+    },
+    "layouts": {
+      "list": [
+        "id",
+        "action",
+        "subject",
+        "role"
+      ],
+      "edit": [
+        [
+          {
+            "name": "action",
+            "size": 6
+          }
+        ],
+        [
+          {
+            "name": "actionParameters",
+            "size": 12
+          }
+        ],
+        [
+          {
+            "name": "subject",
+            "size": 6
+          }
+        ],
+        [
+          {
+            "name": "properties",
+            "size": 12
+          }
+        ],
+        [
+          {
+            "name": "conditions",
+            "size": 12
+          }
+        ],
+        [
+          {
+            "name": "role",
+            "size": 6
+          }
+        ]
+      ]
+    },
+    "uid": "admin::permission"
+  },
+  "type": "object",
+  "environment": null,
+  "tag": null
+}

--- a/config/sync/core-store.plugin_content_manager_configuration_content_types##admin##role.json
+++ b/config/sync/core-store.plugin_content_manager_configuration_content_types##admin##role.json
@@ -1,0 +1,194 @@
+{
+  "key": "plugin_content_manager_configuration_content_types::admin::role",
+  "value": {
+    "settings": {
+      "bulkable": true,
+      "filterable": true,
+      "searchable": true,
+      "pageSize": 10,
+      "mainField": "name",
+      "defaultSortBy": "name",
+      "defaultSortOrder": "ASC"
+    },
+    "metadatas": {
+      "id": {
+        "edit": {},
+        "list": {
+          "label": "id",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "name": {
+        "edit": {
+          "label": "name",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "name",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "code": {
+        "edit": {
+          "label": "code",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "code",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "description": {
+        "edit": {
+          "label": "description",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "description",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "users": {
+        "edit": {
+          "label": "users",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true,
+          "mainField": "firstname"
+        },
+        "list": {
+          "label": "users",
+          "searchable": false,
+          "sortable": false
+        }
+      },
+      "permissions": {
+        "edit": {
+          "label": "permissions",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true,
+          "mainField": "action"
+        },
+        "list": {
+          "label": "permissions",
+          "searchable": false,
+          "sortable": false
+        }
+      },
+      "createdAt": {
+        "edit": {
+          "label": "createdAt",
+          "description": "",
+          "placeholder": "",
+          "visible": false,
+          "editable": true
+        },
+        "list": {
+          "label": "createdAt",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "updatedAt": {
+        "edit": {
+          "label": "updatedAt",
+          "description": "",
+          "placeholder": "",
+          "visible": false,
+          "editable": true
+        },
+        "list": {
+          "label": "updatedAt",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "createdBy": {
+        "edit": {
+          "label": "createdBy",
+          "description": "",
+          "placeholder": "",
+          "visible": false,
+          "editable": true,
+          "mainField": "firstname"
+        },
+        "list": {
+          "label": "createdBy",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "updatedBy": {
+        "edit": {
+          "label": "updatedBy",
+          "description": "",
+          "placeholder": "",
+          "visible": false,
+          "editable": true,
+          "mainField": "firstname"
+        },
+        "list": {
+          "label": "updatedBy",
+          "searchable": true,
+          "sortable": true
+        }
+      }
+    },
+    "layouts": {
+      "list": [
+        "id",
+        "name",
+        "code",
+        "description"
+      ],
+      "edit": [
+        [
+          {
+            "name": "name",
+            "size": 6
+          },
+          {
+            "name": "code",
+            "size": 6
+          }
+        ],
+        [
+          {
+            "name": "description",
+            "size": 6
+          },
+          {
+            "name": "users",
+            "size": 6
+          }
+        ],
+        [
+          {
+            "name": "permissions",
+            "size": 6
+          }
+        ]
+      ]
+    },
+    "uid": "admin::role"
+  },
+  "type": "object",
+  "environment": null,
+  "tag": null
+}

--- a/config/sync/core-store.plugin_content_manager_configuration_content_types##admin##transfer-token-permission.json
+++ b/config/sync/core-store.plugin_content_manager_configuration_content_types##admin##transfer-token-permission.json
@@ -1,0 +1,135 @@
+{
+  "key": "plugin_content_manager_configuration_content_types::admin::transfer-token-permission",
+  "value": {
+    "settings": {
+      "bulkable": true,
+      "filterable": true,
+      "searchable": true,
+      "pageSize": 10,
+      "mainField": "action",
+      "defaultSortBy": "action",
+      "defaultSortOrder": "ASC"
+    },
+    "metadatas": {
+      "id": {
+        "edit": {},
+        "list": {
+          "label": "id",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "action": {
+        "edit": {
+          "label": "action",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "action",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "token": {
+        "edit": {
+          "label": "token",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true,
+          "mainField": "name"
+        },
+        "list": {
+          "label": "token",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "createdAt": {
+        "edit": {
+          "label": "createdAt",
+          "description": "",
+          "placeholder": "",
+          "visible": false,
+          "editable": true
+        },
+        "list": {
+          "label": "createdAt",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "updatedAt": {
+        "edit": {
+          "label": "updatedAt",
+          "description": "",
+          "placeholder": "",
+          "visible": false,
+          "editable": true
+        },
+        "list": {
+          "label": "updatedAt",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "createdBy": {
+        "edit": {
+          "label": "createdBy",
+          "description": "",
+          "placeholder": "",
+          "visible": false,
+          "editable": true,
+          "mainField": "firstname"
+        },
+        "list": {
+          "label": "createdBy",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "updatedBy": {
+        "edit": {
+          "label": "updatedBy",
+          "description": "",
+          "placeholder": "",
+          "visible": false,
+          "editable": true,
+          "mainField": "firstname"
+        },
+        "list": {
+          "label": "updatedBy",
+          "searchable": true,
+          "sortable": true
+        }
+      }
+    },
+    "layouts": {
+      "list": [
+        "id",
+        "action",
+        "token",
+        "createdAt"
+      ],
+      "edit": [
+        [
+          {
+            "name": "action",
+            "size": 6
+          },
+          {
+            "name": "token",
+            "size": 6
+          }
+        ]
+      ]
+    },
+    "uid": "admin::transfer-token-permission"
+  },
+  "type": "object",
+  "environment": null,
+  "tag": null
+}

--- a/config/sync/core-store.plugin_content_manager_configuration_content_types##admin##transfer-token.json
+++ b/config/sync/core-store.plugin_content_manager_configuration_content_types##admin##transfer-token.json
@@ -1,0 +1,231 @@
+{
+  "key": "plugin_content_manager_configuration_content_types::admin::transfer-token",
+  "value": {
+    "settings": {
+      "bulkable": true,
+      "filterable": true,
+      "searchable": true,
+      "pageSize": 10,
+      "mainField": "name",
+      "defaultSortBy": "name",
+      "defaultSortOrder": "ASC"
+    },
+    "metadatas": {
+      "id": {
+        "edit": {},
+        "list": {
+          "label": "id",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "name": {
+        "edit": {
+          "label": "name",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "name",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "description": {
+        "edit": {
+          "label": "description",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "description",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "accessKey": {
+        "edit": {
+          "label": "accessKey",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "accessKey",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "lastUsedAt": {
+        "edit": {
+          "label": "lastUsedAt",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "lastUsedAt",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "permissions": {
+        "edit": {
+          "label": "permissions",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true,
+          "mainField": "action"
+        },
+        "list": {
+          "label": "permissions",
+          "searchable": false,
+          "sortable": false
+        }
+      },
+      "expiresAt": {
+        "edit": {
+          "label": "expiresAt",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "expiresAt",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "lifespan": {
+        "edit": {
+          "label": "lifespan",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "lifespan",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "createdAt": {
+        "edit": {
+          "label": "createdAt",
+          "description": "",
+          "placeholder": "",
+          "visible": false,
+          "editable": true
+        },
+        "list": {
+          "label": "createdAt",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "updatedAt": {
+        "edit": {
+          "label": "updatedAt",
+          "description": "",
+          "placeholder": "",
+          "visible": false,
+          "editable": true
+        },
+        "list": {
+          "label": "updatedAt",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "createdBy": {
+        "edit": {
+          "label": "createdBy",
+          "description": "",
+          "placeholder": "",
+          "visible": false,
+          "editable": true,
+          "mainField": "firstname"
+        },
+        "list": {
+          "label": "createdBy",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "updatedBy": {
+        "edit": {
+          "label": "updatedBy",
+          "description": "",
+          "placeholder": "",
+          "visible": false,
+          "editable": true,
+          "mainField": "firstname"
+        },
+        "list": {
+          "label": "updatedBy",
+          "searchable": true,
+          "sortable": true
+        }
+      }
+    },
+    "layouts": {
+      "list": [
+        "id",
+        "name",
+        "description",
+        "accessKey"
+      ],
+      "edit": [
+        [
+          {
+            "name": "name",
+            "size": 6
+          },
+          {
+            "name": "description",
+            "size": 6
+          }
+        ],
+        [
+          {
+            "name": "accessKey",
+            "size": 6
+          },
+          {
+            "name": "lastUsedAt",
+            "size": 6
+          }
+        ],
+        [
+          {
+            "name": "permissions",
+            "size": 6
+          },
+          {
+            "name": "expiresAt",
+            "size": 6
+          }
+        ],
+        [
+          {
+            "name": "lifespan",
+            "size": 4
+          }
+        ]
+      ]
+    },
+    "uid": "admin::transfer-token"
+  },
+  "type": "object",
+  "environment": null,
+  "tag": null
+}

--- a/config/sync/core-store.plugin_content_manager_configuration_content_types##admin##user.json
+++ b/config/sync/core-store.plugin_content_manager_configuration_content_types##admin##user.json
@@ -1,0 +1,297 @@
+{
+  "key": "plugin_content_manager_configuration_content_types::admin::user",
+  "value": {
+    "settings": {
+      "bulkable": true,
+      "filterable": true,
+      "searchable": true,
+      "pageSize": 10,
+      "mainField": "firstname",
+      "defaultSortBy": "firstname",
+      "defaultSortOrder": "ASC"
+    },
+    "metadatas": {
+      "id": {
+        "edit": {},
+        "list": {
+          "label": "id",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "firstname": {
+        "edit": {
+          "label": "firstname",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "firstname",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "lastname": {
+        "edit": {
+          "label": "lastname",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "lastname",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "username": {
+        "edit": {
+          "label": "username",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "username",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "email": {
+        "edit": {
+          "label": "email",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "email",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "password": {
+        "edit": {
+          "label": "password",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "password",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "resetPasswordToken": {
+        "edit": {
+          "label": "resetPasswordToken",
+          "description": "",
+          "placeholder": "",
+          "visible": false,
+          "editable": true
+        },
+        "list": {
+          "label": "resetPasswordToken",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "registrationToken": {
+        "edit": {
+          "label": "registrationToken",
+          "description": "",
+          "placeholder": "",
+          "visible": false,
+          "editable": true
+        },
+        "list": {
+          "label": "registrationToken",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "isActive": {
+        "edit": {
+          "label": "isActive",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "isActive",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "roles": {
+        "edit": {
+          "label": "roles",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true,
+          "mainField": "name"
+        },
+        "list": {
+          "label": "roles",
+          "searchable": false,
+          "sortable": false
+        }
+      },
+      "blocked": {
+        "edit": {
+          "label": "blocked",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "blocked",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "preferedLanguage": {
+        "edit": {
+          "label": "preferedLanguage",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "preferedLanguage",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "createdAt": {
+        "edit": {
+          "label": "createdAt",
+          "description": "",
+          "placeholder": "",
+          "visible": false,
+          "editable": true
+        },
+        "list": {
+          "label": "createdAt",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "updatedAt": {
+        "edit": {
+          "label": "updatedAt",
+          "description": "",
+          "placeholder": "",
+          "visible": false,
+          "editable": true
+        },
+        "list": {
+          "label": "updatedAt",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "createdBy": {
+        "edit": {
+          "label": "createdBy",
+          "description": "",
+          "placeholder": "",
+          "visible": false,
+          "editable": true,
+          "mainField": "firstname"
+        },
+        "list": {
+          "label": "createdBy",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "updatedBy": {
+        "edit": {
+          "label": "updatedBy",
+          "description": "",
+          "placeholder": "",
+          "visible": false,
+          "editable": true,
+          "mainField": "firstname"
+        },
+        "list": {
+          "label": "updatedBy",
+          "searchable": true,
+          "sortable": true
+        }
+      }
+    },
+    "layouts": {
+      "list": [
+        "id",
+        "firstname",
+        "lastname",
+        "username"
+      ],
+      "edit": [
+        [
+          {
+            "name": "firstname",
+            "size": 6
+          },
+          {
+            "name": "lastname",
+            "size": 6
+          }
+        ],
+        [
+          {
+            "name": "username",
+            "size": 6
+          },
+          {
+            "name": "email",
+            "size": 6
+          }
+        ],
+        [
+          {
+            "name": "password",
+            "size": 6
+          },
+          {
+            "name": "isActive",
+            "size": 4
+          }
+        ],
+        [
+          {
+            "name": "roles",
+            "size": 6
+          },
+          {
+            "name": "blocked",
+            "size": 4
+          }
+        ],
+        [
+          {
+            "name": "preferedLanguage",
+            "size": 6
+          }
+        ]
+      ]
+    },
+    "uid": "admin::user"
+  },
+  "type": "object",
+  "environment": null,
+  "tag": null
+}

--- a/config/sync/core-store.plugin_content_manager_configuration_content_types##api##audience-member.audience-member.json
+++ b/config/sync/core-store.plugin_content_manager_configuration_content_types##api##audience-member.audience-member.json
@@ -84,7 +84,7 @@
           "placeholder": "",
           "visible": true,
           "editable": true,
-          "mainField": "firstname"
+          "mainField": "username"
         },
         "list": {
           "label": "user_id",

--- a/config/sync/core-store.plugin_content_manager_configuration_content_types##api##audience-member.audience-member.json
+++ b/config/sync/core-store.plugin_content_manager_configuration_content_types##api##audience-member.audience-member.json
@@ -62,21 +62,6 @@
           "sortable": true
         }
       },
-      "followed_artists": {
-        "edit": {
-          "label": "followed_artists",
-          "description": "",
-          "placeholder": "",
-          "visible": true,
-          "editable": true,
-          "mainField": "id"
-        },
-        "list": {
-          "label": "followed_artists",
-          "searchable": false,
-          "sortable": false
-        }
-      },
       "user_id": {
         "edit": {
           "label": "user_id",
@@ -173,10 +158,6 @@
           {
             "name": "event_time",
             "size": 4
-          },
-          {
-            "name": "followed_artists",
-            "size": 6
           }
         ],
         [

--- a/config/sync/core-store.plugin_content_manager_configuration_content_types##api##audience-member.audience-member.json
+++ b/config/sync/core-store.plugin_content_manager_configuration_content_types##api##audience-member.audience-member.json
@@ -1,0 +1,195 @@
+{
+  "key": "plugin_content_manager_configuration_content_types::api::audience-member.audience-member",
+  "value": {
+    "settings": {
+      "bulkable": true,
+      "filterable": true,
+      "searchable": true,
+      "pageSize": 10,
+      "mainField": "id",
+      "defaultSortBy": "id",
+      "defaultSortOrder": "ASC"
+    },
+    "metadatas": {
+      "id": {
+        "edit": {},
+        "list": {
+          "label": "id",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "is_quiet": {
+        "edit": {
+          "label": "is_quiet",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "is_quiet",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "playlist": {
+        "edit": {
+          "label": "playlist",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true,
+          "mainField": "title"
+        },
+        "list": {
+          "label": "playlist",
+          "searchable": false,
+          "sortable": false
+        }
+      },
+      "event_time": {
+        "edit": {
+          "label": "event_time",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "event_time",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "followed_artists": {
+        "edit": {
+          "label": "followed_artists",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true,
+          "mainField": "id"
+        },
+        "list": {
+          "label": "followed_artists",
+          "searchable": false,
+          "sortable": false
+        }
+      },
+      "user_id": {
+        "edit": {
+          "label": "user_id",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true,
+          "mainField": "firstname"
+        },
+        "list": {
+          "label": "user_id",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "createdAt": {
+        "edit": {
+          "label": "createdAt",
+          "description": "",
+          "placeholder": "",
+          "visible": false,
+          "editable": true
+        },
+        "list": {
+          "label": "createdAt",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "updatedAt": {
+        "edit": {
+          "label": "updatedAt",
+          "description": "",
+          "placeholder": "",
+          "visible": false,
+          "editable": true
+        },
+        "list": {
+          "label": "updatedAt",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "createdBy": {
+        "edit": {
+          "label": "createdBy",
+          "description": "",
+          "placeholder": "",
+          "visible": false,
+          "editable": true,
+          "mainField": "firstname"
+        },
+        "list": {
+          "label": "createdBy",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "updatedBy": {
+        "edit": {
+          "label": "updatedBy",
+          "description": "",
+          "placeholder": "",
+          "visible": false,
+          "editable": true,
+          "mainField": "firstname"
+        },
+        "list": {
+          "label": "updatedBy",
+          "searchable": true,
+          "sortable": true
+        }
+      }
+    },
+    "layouts": {
+      "list": [
+        "id",
+        "is_quiet",
+        "playlist",
+        "event_time"
+      ],
+      "edit": [
+        [
+          {
+            "name": "is_quiet",
+            "size": 4
+          },
+          {
+            "name": "playlist",
+            "size": 6
+          }
+        ],
+        [
+          {
+            "name": "event_time",
+            "size": 4
+          },
+          {
+            "name": "followed_artists",
+            "size": 6
+          }
+        ],
+        [
+          {
+            "name": "user_id",
+            "size": 6
+          }
+        ]
+      ]
+    },
+    "uid": "api::audience-member.audience-member"
+  },
+  "type": "object",
+  "environment": null,
+  "tag": null
+}

--- a/config/sync/core-store.plugin_content_manager_configuration_content_types##api##content-creator.content-creator.json
+++ b/config/sync/core-store.plugin_content_manager_configuration_content_types##api##content-creator.content-creator.json
@@ -48,32 +48,16 @@
           "sortable": false
         }
       },
-      "followers": {
+      "artist_name": {
         "edit": {
-          "label": "followers",
+          "label": "artist_name",
           "description": "",
           "placeholder": "",
           "visible": true,
-          "editable": true,
-          "mainField": "id"
+          "editable": true
         },
         "list": {
-          "label": "followers",
-          "searchable": false,
-          "sortable": false
-        }
-      },
-      "admin_user": {
-        "edit": {
-          "label": "admin_user",
-          "description": "",
-          "placeholder": "",
-          "visible": true,
-          "editable": true,
-          "mainField": "firstname"
-        },
-        "list": {
-          "label": "admin_user",
+          "label": "artist_name",
           "searchable": true,
           "sortable": true
         }
@@ -138,13 +122,13 @@
       }
     },
     "layouts": {
-      "list": [
-        "id",
-        "projects",
-        "followers",
-        "admin_user"
-      ],
       "edit": [
+        [
+          {
+            "name": "artist_name",
+            "size": 6
+          }
+        ],
         [
           {
             "name": "bio",
@@ -155,18 +139,13 @@
           {
             "name": "projects",
             "size": 6
-          },
-          {
-            "name": "followers",
-            "size": 6
-          }
-        ],
-        [
-          {
-            "name": "admin_user",
-            "size": 6
           }
         ]
+      ],
+      "list": [
+        "id",
+        "projects",
+        "artist_name"
       ]
     },
     "uid": "api::content-creator.content-creator"

--- a/config/sync/core-store.plugin_content_manager_configuration_content_types##api##content-creator.content-creator.json
+++ b/config/sync/core-store.plugin_content_manager_configuration_content_types##api##content-creator.content-creator.json
@@ -63,17 +63,17 @@
           "sortable": false
         }
       },
-      "user_id": {
+      "admin_user": {
         "edit": {
-          "label": "user_id",
+          "label": "admin_user",
           "description": "",
           "placeholder": "",
           "visible": true,
           "editable": true,
-          "mainField": "username"
+          "mainField": "firstname"
         },
         "list": {
-          "label": "user_id",
+          "label": "admin_user",
           "searchable": true,
           "sortable": true
         }
@@ -142,7 +142,7 @@
         "id",
         "projects",
         "followers",
-        "user_id"
+        "admin_user"
       ],
       "edit": [
         [
@@ -163,7 +163,7 @@
         ],
         [
           {
-            "name": "user_id",
+            "name": "admin_user",
             "size": 6
           }
         ]

--- a/config/sync/core-store.plugin_content_manager_configuration_content_types##api##content-creator.content-creator.json
+++ b/config/sync/core-store.plugin_content_manager_configuration_content_types##api##content-creator.content-creator.json
@@ -1,0 +1,177 @@
+{
+  "key": "plugin_content_manager_configuration_content_types::api::content-creator.content-creator",
+  "value": {
+    "settings": {
+      "bulkable": true,
+      "filterable": true,
+      "searchable": true,
+      "pageSize": 10,
+      "mainField": "id",
+      "defaultSortBy": "id",
+      "defaultSortOrder": "ASC"
+    },
+    "metadatas": {
+      "id": {
+        "edit": {},
+        "list": {
+          "label": "id",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "bio": {
+        "edit": {
+          "label": "bio",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "bio",
+          "searchable": false,
+          "sortable": false
+        }
+      },
+      "projects": {
+        "edit": {
+          "label": "projects",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true,
+          "mainField": "title"
+        },
+        "list": {
+          "label": "projects",
+          "searchable": false,
+          "sortable": false
+        }
+      },
+      "followers": {
+        "edit": {
+          "label": "followers",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true,
+          "mainField": "id"
+        },
+        "list": {
+          "label": "followers",
+          "searchable": false,
+          "sortable": false
+        }
+      },
+      "user_id": {
+        "edit": {
+          "label": "user_id",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true,
+          "mainField": "username"
+        },
+        "list": {
+          "label": "user_id",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "createdAt": {
+        "edit": {
+          "label": "createdAt",
+          "description": "",
+          "placeholder": "",
+          "visible": false,
+          "editable": true
+        },
+        "list": {
+          "label": "createdAt",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "updatedAt": {
+        "edit": {
+          "label": "updatedAt",
+          "description": "",
+          "placeholder": "",
+          "visible": false,
+          "editable": true
+        },
+        "list": {
+          "label": "updatedAt",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "createdBy": {
+        "edit": {
+          "label": "createdBy",
+          "description": "",
+          "placeholder": "",
+          "visible": false,
+          "editable": true,
+          "mainField": "firstname"
+        },
+        "list": {
+          "label": "createdBy",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "updatedBy": {
+        "edit": {
+          "label": "updatedBy",
+          "description": "",
+          "placeholder": "",
+          "visible": false,
+          "editable": true,
+          "mainField": "firstname"
+        },
+        "list": {
+          "label": "updatedBy",
+          "searchable": true,
+          "sortable": true
+        }
+      }
+    },
+    "layouts": {
+      "list": [
+        "id",
+        "projects",
+        "followers",
+        "user_id"
+      ],
+      "edit": [
+        [
+          {
+            "name": "bio",
+            "size": 12
+          }
+        ],
+        [
+          {
+            "name": "projects",
+            "size": 6
+          },
+          {
+            "name": "followers",
+            "size": 6
+          }
+        ],
+        [
+          {
+            "name": "user_id",
+            "size": 6
+          }
+        ]
+      ]
+    },
+    "uid": "api::content-creator.content-creator"
+  },
+  "type": "object",
+  "environment": null,
+  "tag": null
+}

--- a/config/sync/core-store.plugin_content_manager_configuration_content_types##api##event.event.json
+++ b/config/sync/core-store.plugin_content_manager_configuration_content_types##api##event.event.json
@@ -33,23 +33,9 @@
           "sortable": true
         }
       },
-      "pieces": {
+      "in_project": {
         "edit": {
-          "label": "pieces",
-          "description": "",
-          "placeholder": "",
-          "visible": true,
-          "editable": true
-        },
-        "list": {
-          "label": "pieces",
-          "searchable": false,
-          "sortable": false
-        }
-      },
-      "project": {
-        "edit": {
-          "label": "project",
+          "label": "in_project",
           "description": "",
           "placeholder": "",
           "visible": true,
@@ -57,9 +43,38 @@
           "mainField": "title"
         },
         "list": {
-          "label": "project",
+          "label": "in_project",
           "searchable": true,
           "sortable": true
+        }
+      },
+      "pop_ups": {
+        "edit": {
+          "label": "pop_ups",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true,
+          "mainField": "title"
+        },
+        "list": {
+          "label": "pop_ups",
+          "searchable": false,
+          "sortable": false
+        }
+      },
+      "event_description": {
+        "edit": {
+          "label": "event_description",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "event_description",
+          "searchable": false,
+          "sortable": false
         }
       },
       "createdAt": {
@@ -122,12 +137,6 @@
       }
     },
     "layouts": {
-      "list": [
-        "id",
-        "title",
-        "createdAt",
-        "pieces"
-      ],
       "edit": [
         [
           {
@@ -137,16 +146,26 @@
         ],
         [
           {
-            "name": "pieces",
+            "name": "event_description",
             "size": 12
           }
         ],
         [
           {
-            "name": "project",
+            "name": "pop_ups",
+            "size": 6
+          },
+          {
+            "name": "in_project",
             "size": 6
           }
         ]
+      ],
+      "list": [
+        "id",
+        "title",
+        "createdAt",
+        "pop_ups"
       ]
     },
     "uid": "api::event.event"

--- a/config/sync/core-store.plugin_content_manager_configuration_content_types##api##event.event.json
+++ b/config/sync/core-store.plugin_content_manager_configuration_content_types##api##event.event.json
@@ -1,0 +1,157 @@
+{
+  "key": "plugin_content_manager_configuration_content_types::api::event.event",
+  "value": {
+    "settings": {
+      "bulkable": true,
+      "filterable": true,
+      "searchable": true,
+      "pageSize": 10,
+      "mainField": "title",
+      "defaultSortBy": "title",
+      "defaultSortOrder": "ASC"
+    },
+    "metadatas": {
+      "id": {
+        "edit": {},
+        "list": {
+          "label": "id",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "title": {
+        "edit": {
+          "label": "title",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "title",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "pieces": {
+        "edit": {
+          "label": "pieces",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "pieces",
+          "searchable": false,
+          "sortable": false
+        }
+      },
+      "project": {
+        "edit": {
+          "label": "project",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true,
+          "mainField": "title"
+        },
+        "list": {
+          "label": "project",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "createdAt": {
+        "edit": {
+          "label": "createdAt",
+          "description": "",
+          "placeholder": "",
+          "visible": false,
+          "editable": true
+        },
+        "list": {
+          "label": "createdAt",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "updatedAt": {
+        "edit": {
+          "label": "updatedAt",
+          "description": "",
+          "placeholder": "",
+          "visible": false,
+          "editable": true
+        },
+        "list": {
+          "label": "updatedAt",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "createdBy": {
+        "edit": {
+          "label": "createdBy",
+          "description": "",
+          "placeholder": "",
+          "visible": false,
+          "editable": true,
+          "mainField": "firstname"
+        },
+        "list": {
+          "label": "createdBy",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "updatedBy": {
+        "edit": {
+          "label": "updatedBy",
+          "description": "",
+          "placeholder": "",
+          "visible": false,
+          "editable": true,
+          "mainField": "firstname"
+        },
+        "list": {
+          "label": "updatedBy",
+          "searchable": true,
+          "sortable": true
+        }
+      }
+    },
+    "layouts": {
+      "list": [
+        "id",
+        "title",
+        "createdAt",
+        "pieces"
+      ],
+      "edit": [
+        [
+          {
+            "name": "title",
+            "size": 6
+          }
+        ],
+        [
+          {
+            "name": "pieces",
+            "size": 12
+          }
+        ],
+        [
+          {
+            "name": "project",
+            "size": 6
+          }
+        ]
+      ]
+    },
+    "uid": "api::event.event"
+  },
+  "type": "object",
+  "environment": null,
+  "tag": null
+}

--- a/config/sync/core-store.plugin_content_manager_configuration_content_types##api##pop-up.pop-up.json
+++ b/config/sync/core-store.plugin_content_manager_configuration_content_types##api##pop-up.pop-up.json
@@ -1,5 +1,5 @@
 {
-  "key": "plugin_content_manager_configuration_content_types::api::project.project",
+  "key": "plugin_content_manager_configuration_content_types::api::pop-up.pop-up",
   "value": {
     "settings": {
       "bulkable": true,
@@ -33,6 +33,20 @@
           "sortable": true
         }
       },
+      "media": {
+        "edit": {
+          "label": "media",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "media",
+          "searchable": false,
+          "sortable": false
+        }
+      },
       "description": {
         "edit": {
           "label": "description",
@@ -47,62 +61,32 @@
           "sortable": false
         }
       },
-      "launch_date": {
+      "popup_size": {
         "edit": {
-          "label": "launch_date",
+          "label": "popup_size",
           "description": "",
           "placeholder": "",
           "visible": true,
           "editable": true
         },
         "list": {
-          "label": "launch_date",
+          "label": "popup_size",
           "searchable": true,
           "sortable": true
         }
       },
-      "cover_image": {
+      "popup_position": {
         "edit": {
-          "label": "cover_image",
+          "label": "popup_position",
           "description": "",
           "placeholder": "",
           "visible": true,
           "editable": true
         },
         "list": {
-          "label": "cover_image",
-          "searchable": false,
-          "sortable": false
-        }
-      },
-      "content_creator": {
-        "edit": {
-          "label": "content_creator",
-          "description": "",
-          "placeholder": "",
-          "visible": true,
-          "editable": true,
-          "mainField": "id"
-        },
-        "list": {
-          "label": "content_creator",
+          "label": "popup_position",
           "searchable": true,
           "sortable": true
-        }
-      },
-      "events": {
-        "edit": {
-          "label": "events",
-          "description": "",
-          "placeholder": "",
-          "visible": true,
-          "editable": true,
-          "mainField": "title"
-        },
-        "list": {
-          "label": "events",
-          "searchable": false,
-          "sortable": false
         }
       },
       "createdAt": {
@@ -165,6 +149,12 @@
       }
     },
     "layouts": {
+      "list": [
+        "id",
+        "title",
+        "media",
+        "createdAt"
+      ],
       "edit": [
         [
           {
@@ -172,13 +162,7 @@
             "size": 6
           },
           {
-            "name": "cover_image",
-            "size": 6
-          }
-        ],
-        [
-          {
-            "name": "events",
+            "name": "media",
             "size": 6
           }
         ],
@@ -190,23 +174,17 @@
         ],
         [
           {
-            "name": "launch_date",
-            "size": 4
+            "name": "popup_size",
+            "size": 6
           },
           {
-            "name": "content_creator",
+            "name": "popup_position",
             "size": 6
           }
         ]
-      ],
-      "list": [
-        "id",
-        "title",
-        "launch_date",
-        "cover_image"
       ]
     },
-    "uid": "api::project.project"
+    "uid": "api::pop-up.pop-up"
   },
   "type": "object",
   "environment": null,

--- a/config/sync/core-store.plugin_content_manager_configuration_content_types##api##project.project.json
+++ b/config/sync/core-store.plugin_content_manager_configuration_content_types##api##project.project.json
@@ -192,10 +192,6 @@
           {
             "name": "launch_date",
             "size": 4
-          },
-          {
-            "name": "content_creator",
-            "size": 6
           }
         ]
       ],

--- a/config/sync/core-store.plugin_content_manager_configuration_content_types##api##project.project.json
+++ b/config/sync/core-store.plugin_content_manager_configuration_content_types##api##project.project.json
@@ -1,0 +1,214 @@
+{
+  "key": "plugin_content_manager_configuration_content_types::api::project.project",
+  "value": {
+    "settings": {
+      "bulkable": true,
+      "filterable": true,
+      "searchable": true,
+      "pageSize": 10,
+      "mainField": "title",
+      "defaultSortBy": "title",
+      "defaultSortOrder": "ASC"
+    },
+    "metadatas": {
+      "id": {
+        "edit": {},
+        "list": {
+          "label": "id",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "title": {
+        "edit": {
+          "label": "title",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "title",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "description": {
+        "edit": {
+          "label": "description",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "description",
+          "searchable": false,
+          "sortable": false
+        }
+      },
+      "launch_date": {
+        "edit": {
+          "label": "launch_date",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "launch_date",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "cover_image": {
+        "edit": {
+          "label": "cover_image",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "cover_image",
+          "searchable": false,
+          "sortable": false
+        }
+      },
+      "content_creator": {
+        "edit": {
+          "label": "content_creator",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true,
+          "mainField": "id"
+        },
+        "list": {
+          "label": "content_creator",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "events": {
+        "edit": {
+          "label": "events",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true,
+          "mainField": "title"
+        },
+        "list": {
+          "label": "events",
+          "searchable": false,
+          "sortable": false
+        }
+      },
+      "createdAt": {
+        "edit": {
+          "label": "createdAt",
+          "description": "",
+          "placeholder": "",
+          "visible": false,
+          "editable": true
+        },
+        "list": {
+          "label": "createdAt",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "updatedAt": {
+        "edit": {
+          "label": "updatedAt",
+          "description": "",
+          "placeholder": "",
+          "visible": false,
+          "editable": true
+        },
+        "list": {
+          "label": "updatedAt",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "createdBy": {
+        "edit": {
+          "label": "createdBy",
+          "description": "",
+          "placeholder": "",
+          "visible": false,
+          "editable": true,
+          "mainField": "firstname"
+        },
+        "list": {
+          "label": "createdBy",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "updatedBy": {
+        "edit": {
+          "label": "updatedBy",
+          "description": "",
+          "placeholder": "",
+          "visible": false,
+          "editable": true,
+          "mainField": "firstname"
+        },
+        "list": {
+          "label": "updatedBy",
+          "searchable": true,
+          "sortable": true
+        }
+      }
+    },
+    "layouts": {
+      "list": [
+        "id",
+        "title",
+        "launch_date",
+        "cover_image"
+      ],
+      "edit": [
+        [
+          {
+            "name": "title",
+            "size": 6
+          }
+        ],
+        [
+          {
+            "name": "description",
+            "size": 12
+          }
+        ],
+        [
+          {
+            "name": "launch_date",
+            "size": 4
+          },
+          {
+            "name": "cover_image",
+            "size": 6
+          }
+        ],
+        [
+          {
+            "name": "content_creator",
+            "size": 6
+          },
+          {
+            "name": "events",
+            "size": 6
+          }
+        ]
+      ]
+    },
+    "uid": "api::project.project"
+  },
+  "type": "object",
+  "environment": null,
+  "tag": null
+}

--- a/config/sync/core-store.plugin_content_manager_configuration_content_types##plugin##content-releases.release-action.json
+++ b/config/sync/core-store.plugin_content_manager_configuration_content_types##plugin##content-releases.release-action.json
@@ -1,0 +1,193 @@
+{
+  "key": "plugin_content_manager_configuration_content_types::plugin::content-releases.release-action",
+  "value": {
+    "settings": {
+      "bulkable": true,
+      "filterable": true,
+      "searchable": true,
+      "pageSize": 10,
+      "mainField": "contentType",
+      "defaultSortBy": "contentType",
+      "defaultSortOrder": "ASC"
+    },
+    "metadatas": {
+      "id": {
+        "edit": {},
+        "list": {
+          "label": "id",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "type": {
+        "edit": {
+          "label": "type",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "type",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "contentType": {
+        "edit": {
+          "label": "contentType",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "contentType",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "locale": {
+        "edit": {
+          "label": "locale",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "locale",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "release": {
+        "edit": {
+          "label": "release",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true,
+          "mainField": "name"
+        },
+        "list": {
+          "label": "release",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "isEntryValid": {
+        "edit": {
+          "label": "isEntryValid",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "isEntryValid",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "createdAt": {
+        "edit": {
+          "label": "createdAt",
+          "description": "",
+          "placeholder": "",
+          "visible": false,
+          "editable": true
+        },
+        "list": {
+          "label": "createdAt",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "updatedAt": {
+        "edit": {
+          "label": "updatedAt",
+          "description": "",
+          "placeholder": "",
+          "visible": false,
+          "editable": true
+        },
+        "list": {
+          "label": "updatedAt",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "createdBy": {
+        "edit": {
+          "label": "createdBy",
+          "description": "",
+          "placeholder": "",
+          "visible": false,
+          "editable": true,
+          "mainField": "firstname"
+        },
+        "list": {
+          "label": "createdBy",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "updatedBy": {
+        "edit": {
+          "label": "updatedBy",
+          "description": "",
+          "placeholder": "",
+          "visible": false,
+          "editable": true,
+          "mainField": "firstname"
+        },
+        "list": {
+          "label": "updatedBy",
+          "searchable": true,
+          "sortable": true
+        }
+      }
+    },
+    "layouts": {
+      "list": [
+        "id",
+        "type",
+        "contentType",
+        "locale"
+      ],
+      "edit": [
+        [
+          {
+            "name": "type",
+            "size": 6
+          },
+          {
+            "name": "contentType",
+            "size": 6
+          }
+        ],
+        [
+          {
+            "name": "locale",
+            "size": 6
+          },
+          {
+            "name": "release",
+            "size": 6
+          }
+        ],
+        [
+          {
+            "name": "isEntryValid",
+            "size": 4
+          }
+        ]
+      ]
+    },
+    "uid": "plugin::content-releases.release-action"
+  },
+  "type": "object",
+  "environment": null,
+  "tag": null
+}

--- a/config/sync/core-store.plugin_content_manager_configuration_content_types##plugin##content-releases.release.json
+++ b/config/sync/core-store.plugin_content_manager_configuration_content_types##plugin##content-releases.release.json
@@ -1,0 +1,211 @@
+{
+  "key": "plugin_content_manager_configuration_content_types::plugin::content-releases.release",
+  "value": {
+    "settings": {
+      "bulkable": true,
+      "filterable": true,
+      "searchable": true,
+      "pageSize": 10,
+      "mainField": "name",
+      "defaultSortBy": "name",
+      "defaultSortOrder": "ASC"
+    },
+    "metadatas": {
+      "id": {
+        "edit": {},
+        "list": {
+          "label": "id",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "name": {
+        "edit": {
+          "label": "name",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "name",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "releasedAt": {
+        "edit": {
+          "label": "releasedAt",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "releasedAt",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "scheduledAt": {
+        "edit": {
+          "label": "scheduledAt",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "scheduledAt",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "timezone": {
+        "edit": {
+          "label": "timezone",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "timezone",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "status": {
+        "edit": {
+          "label": "status",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "status",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "actions": {
+        "edit": {
+          "label": "actions",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true,
+          "mainField": "contentType"
+        },
+        "list": {
+          "label": "actions",
+          "searchable": false,
+          "sortable": false
+        }
+      },
+      "createdAt": {
+        "edit": {
+          "label": "createdAt",
+          "description": "",
+          "placeholder": "",
+          "visible": false,
+          "editable": true
+        },
+        "list": {
+          "label": "createdAt",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "updatedAt": {
+        "edit": {
+          "label": "updatedAt",
+          "description": "",
+          "placeholder": "",
+          "visible": false,
+          "editable": true
+        },
+        "list": {
+          "label": "updatedAt",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "createdBy": {
+        "edit": {
+          "label": "createdBy",
+          "description": "",
+          "placeholder": "",
+          "visible": false,
+          "editable": true,
+          "mainField": "firstname"
+        },
+        "list": {
+          "label": "createdBy",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "updatedBy": {
+        "edit": {
+          "label": "updatedBy",
+          "description": "",
+          "placeholder": "",
+          "visible": false,
+          "editable": true,
+          "mainField": "firstname"
+        },
+        "list": {
+          "label": "updatedBy",
+          "searchable": true,
+          "sortable": true
+        }
+      }
+    },
+    "layouts": {
+      "list": [
+        "id",
+        "name",
+        "releasedAt",
+        "scheduledAt"
+      ],
+      "edit": [
+        [
+          {
+            "name": "name",
+            "size": 6
+          },
+          {
+            "name": "releasedAt",
+            "size": 6
+          }
+        ],
+        [
+          {
+            "name": "scheduledAt",
+            "size": 6
+          },
+          {
+            "name": "timezone",
+            "size": 6
+          }
+        ],
+        [
+          {
+            "name": "status",
+            "size": 6
+          },
+          {
+            "name": "actions",
+            "size": 6
+          }
+        ]
+      ]
+    },
+    "uid": "plugin::content-releases.release"
+  },
+  "type": "object",
+  "environment": null,
+  "tag": null
+}

--- a/config/sync/core-store.plugin_content_manager_configuration_content_types##plugin##i18n.locale.json
+++ b/config/sync/core-store.plugin_content_manager_configuration_content_types##plugin##i18n.locale.json
@@ -1,0 +1,134 @@
+{
+  "key": "plugin_content_manager_configuration_content_types::plugin::i18n.locale",
+  "value": {
+    "settings": {
+      "bulkable": true,
+      "filterable": true,
+      "searchable": true,
+      "pageSize": 10,
+      "mainField": "name",
+      "defaultSortBy": "name",
+      "defaultSortOrder": "ASC"
+    },
+    "metadatas": {
+      "id": {
+        "edit": {},
+        "list": {
+          "label": "id",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "name": {
+        "edit": {
+          "label": "name",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "name",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "code": {
+        "edit": {
+          "label": "code",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "code",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "createdAt": {
+        "edit": {
+          "label": "createdAt",
+          "description": "",
+          "placeholder": "",
+          "visible": false,
+          "editable": true
+        },
+        "list": {
+          "label": "createdAt",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "updatedAt": {
+        "edit": {
+          "label": "updatedAt",
+          "description": "",
+          "placeholder": "",
+          "visible": false,
+          "editable": true
+        },
+        "list": {
+          "label": "updatedAt",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "createdBy": {
+        "edit": {
+          "label": "createdBy",
+          "description": "",
+          "placeholder": "",
+          "visible": false,
+          "editable": true,
+          "mainField": "firstname"
+        },
+        "list": {
+          "label": "createdBy",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "updatedBy": {
+        "edit": {
+          "label": "updatedBy",
+          "description": "",
+          "placeholder": "",
+          "visible": false,
+          "editable": true,
+          "mainField": "firstname"
+        },
+        "list": {
+          "label": "updatedBy",
+          "searchable": true,
+          "sortable": true
+        }
+      }
+    },
+    "layouts": {
+      "list": [
+        "id",
+        "name",
+        "code",
+        "createdAt"
+      ],
+      "edit": [
+        [
+          {
+            "name": "name",
+            "size": 6
+          },
+          {
+            "name": "code",
+            "size": 6
+          }
+        ]
+      ]
+    },
+    "uid": "plugin::i18n.locale"
+  },
+  "type": "object",
+  "environment": null,
+  "tag": null
+}

--- a/config/sync/core-store.plugin_content_manager_configuration_content_types##plugin##upload.file.json
+++ b/config/sync/core-store.plugin_content_manager_configuration_content_types##plugin##upload.file.json
@@ -1,0 +1,405 @@
+{
+  "key": "plugin_content_manager_configuration_content_types::plugin::upload.file",
+  "value": {
+    "settings": {
+      "bulkable": true,
+      "filterable": true,
+      "searchable": true,
+      "pageSize": 10,
+      "mainField": "name",
+      "defaultSortBy": "name",
+      "defaultSortOrder": "ASC"
+    },
+    "metadatas": {
+      "id": {
+        "edit": {},
+        "list": {
+          "label": "id",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "name": {
+        "edit": {
+          "label": "name",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "name",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "alternativeText": {
+        "edit": {
+          "label": "alternativeText",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "alternativeText",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "caption": {
+        "edit": {
+          "label": "caption",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "caption",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "width": {
+        "edit": {
+          "label": "width",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "width",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "height": {
+        "edit": {
+          "label": "height",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "height",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "formats": {
+        "edit": {
+          "label": "formats",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "formats",
+          "searchable": false,
+          "sortable": false
+        }
+      },
+      "hash": {
+        "edit": {
+          "label": "hash",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "hash",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "ext": {
+        "edit": {
+          "label": "ext",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "ext",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "mime": {
+        "edit": {
+          "label": "mime",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "mime",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "size": {
+        "edit": {
+          "label": "size",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "size",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "url": {
+        "edit": {
+          "label": "url",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "url",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "previewUrl": {
+        "edit": {
+          "label": "previewUrl",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "previewUrl",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "provider": {
+        "edit": {
+          "label": "provider",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "provider",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "provider_metadata": {
+        "edit": {
+          "label": "provider_metadata",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "provider_metadata",
+          "searchable": false,
+          "sortable": false
+        }
+      },
+      "folder": {
+        "edit": {
+          "label": "folder",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true,
+          "mainField": "name"
+        },
+        "list": {
+          "label": "folder",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "folderPath": {
+        "edit": {
+          "label": "folderPath",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "folderPath",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "createdAt": {
+        "edit": {
+          "label": "createdAt",
+          "description": "",
+          "placeholder": "",
+          "visible": false,
+          "editable": true
+        },
+        "list": {
+          "label": "createdAt",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "updatedAt": {
+        "edit": {
+          "label": "updatedAt",
+          "description": "",
+          "placeholder": "",
+          "visible": false,
+          "editable": true
+        },
+        "list": {
+          "label": "updatedAt",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "createdBy": {
+        "edit": {
+          "label": "createdBy",
+          "description": "",
+          "placeholder": "",
+          "visible": false,
+          "editable": true,
+          "mainField": "firstname"
+        },
+        "list": {
+          "label": "createdBy",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "updatedBy": {
+        "edit": {
+          "label": "updatedBy",
+          "description": "",
+          "placeholder": "",
+          "visible": false,
+          "editable": true,
+          "mainField": "firstname"
+        },
+        "list": {
+          "label": "updatedBy",
+          "searchable": true,
+          "sortable": true
+        }
+      }
+    },
+    "layouts": {
+      "list": [
+        "id",
+        "name",
+        "alternativeText",
+        "caption"
+      ],
+      "edit": [
+        [
+          {
+            "name": "name",
+            "size": 6
+          },
+          {
+            "name": "alternativeText",
+            "size": 6
+          }
+        ],
+        [
+          {
+            "name": "caption",
+            "size": 6
+          },
+          {
+            "name": "width",
+            "size": 4
+          }
+        ],
+        [
+          {
+            "name": "height",
+            "size": 4
+          }
+        ],
+        [
+          {
+            "name": "formats",
+            "size": 12
+          }
+        ],
+        [
+          {
+            "name": "hash",
+            "size": 6
+          },
+          {
+            "name": "ext",
+            "size": 6
+          }
+        ],
+        [
+          {
+            "name": "mime",
+            "size": 6
+          },
+          {
+            "name": "size",
+            "size": 4
+          }
+        ],
+        [
+          {
+            "name": "url",
+            "size": 6
+          },
+          {
+            "name": "previewUrl",
+            "size": 6
+          }
+        ],
+        [
+          {
+            "name": "provider",
+            "size": 6
+          }
+        ],
+        [
+          {
+            "name": "provider_metadata",
+            "size": 12
+          }
+        ],
+        [
+          {
+            "name": "folder",
+            "size": 6
+          },
+          {
+            "name": "folderPath",
+            "size": 6
+          }
+        ]
+      ]
+    },
+    "uid": "plugin::upload.file"
+  },
+  "type": "object",
+  "environment": null,
+  "tag": null
+}

--- a/config/sync/core-store.plugin_content_manager_configuration_content_types##plugin##upload.folder.json
+++ b/config/sync/core-store.plugin_content_manager_configuration_content_types##plugin##upload.folder.json
@@ -1,0 +1,213 @@
+{
+  "key": "plugin_content_manager_configuration_content_types::plugin::upload.folder",
+  "value": {
+    "settings": {
+      "bulkable": true,
+      "filterable": true,
+      "searchable": true,
+      "pageSize": 10,
+      "mainField": "name",
+      "defaultSortBy": "name",
+      "defaultSortOrder": "ASC"
+    },
+    "metadatas": {
+      "id": {
+        "edit": {},
+        "list": {
+          "label": "id",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "name": {
+        "edit": {
+          "label": "name",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "name",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "pathId": {
+        "edit": {
+          "label": "pathId",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "pathId",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "parent": {
+        "edit": {
+          "label": "parent",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true,
+          "mainField": "name"
+        },
+        "list": {
+          "label": "parent",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "children": {
+        "edit": {
+          "label": "children",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true,
+          "mainField": "name"
+        },
+        "list": {
+          "label": "children",
+          "searchable": false,
+          "sortable": false
+        }
+      },
+      "files": {
+        "edit": {
+          "label": "files",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true,
+          "mainField": "name"
+        },
+        "list": {
+          "label": "files",
+          "searchable": false,
+          "sortable": false
+        }
+      },
+      "path": {
+        "edit": {
+          "label": "path",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "path",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "createdAt": {
+        "edit": {
+          "label": "createdAt",
+          "description": "",
+          "placeholder": "",
+          "visible": false,
+          "editable": true
+        },
+        "list": {
+          "label": "createdAt",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "updatedAt": {
+        "edit": {
+          "label": "updatedAt",
+          "description": "",
+          "placeholder": "",
+          "visible": false,
+          "editable": true
+        },
+        "list": {
+          "label": "updatedAt",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "createdBy": {
+        "edit": {
+          "label": "createdBy",
+          "description": "",
+          "placeholder": "",
+          "visible": false,
+          "editable": true,
+          "mainField": "firstname"
+        },
+        "list": {
+          "label": "createdBy",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "updatedBy": {
+        "edit": {
+          "label": "updatedBy",
+          "description": "",
+          "placeholder": "",
+          "visible": false,
+          "editable": true,
+          "mainField": "firstname"
+        },
+        "list": {
+          "label": "updatedBy",
+          "searchable": true,
+          "sortable": true
+        }
+      }
+    },
+    "layouts": {
+      "list": [
+        "id",
+        "name",
+        "pathId",
+        "parent"
+      ],
+      "edit": [
+        [
+          {
+            "name": "name",
+            "size": 6
+          },
+          {
+            "name": "pathId",
+            "size": 4
+          }
+        ],
+        [
+          {
+            "name": "parent",
+            "size": 6
+          },
+          {
+            "name": "children",
+            "size": 6
+          }
+        ],
+        [
+          {
+            "name": "files",
+            "size": 6
+          },
+          {
+            "name": "path",
+            "size": 6
+          }
+        ]
+      ]
+    },
+    "uid": "plugin::upload.folder"
+  },
+  "type": "object",
+  "environment": null,
+  "tag": null
+}

--- a/config/sync/core-store.plugin_content_manager_configuration_content_types##plugin##users-permissions.permission.json
+++ b/config/sync/core-store.plugin_content_manager_configuration_content_types##plugin##users-permissions.permission.json
@@ -1,0 +1,135 @@
+{
+  "key": "plugin_content_manager_configuration_content_types::plugin::users-permissions.permission",
+  "value": {
+    "settings": {
+      "bulkable": true,
+      "filterable": true,
+      "searchable": true,
+      "pageSize": 10,
+      "mainField": "action",
+      "defaultSortBy": "action",
+      "defaultSortOrder": "ASC"
+    },
+    "metadatas": {
+      "id": {
+        "edit": {},
+        "list": {
+          "label": "id",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "action": {
+        "edit": {
+          "label": "action",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "action",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "role": {
+        "edit": {
+          "label": "role",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true,
+          "mainField": "name"
+        },
+        "list": {
+          "label": "role",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "createdAt": {
+        "edit": {
+          "label": "createdAt",
+          "description": "",
+          "placeholder": "",
+          "visible": false,
+          "editable": true
+        },
+        "list": {
+          "label": "createdAt",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "updatedAt": {
+        "edit": {
+          "label": "updatedAt",
+          "description": "",
+          "placeholder": "",
+          "visible": false,
+          "editable": true
+        },
+        "list": {
+          "label": "updatedAt",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "createdBy": {
+        "edit": {
+          "label": "createdBy",
+          "description": "",
+          "placeholder": "",
+          "visible": false,
+          "editable": true,
+          "mainField": "firstname"
+        },
+        "list": {
+          "label": "createdBy",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "updatedBy": {
+        "edit": {
+          "label": "updatedBy",
+          "description": "",
+          "placeholder": "",
+          "visible": false,
+          "editable": true,
+          "mainField": "firstname"
+        },
+        "list": {
+          "label": "updatedBy",
+          "searchable": true,
+          "sortable": true
+        }
+      }
+    },
+    "layouts": {
+      "list": [
+        "id",
+        "action",
+        "role",
+        "createdAt"
+      ],
+      "edit": [
+        [
+          {
+            "name": "action",
+            "size": 6
+          },
+          {
+            "name": "role",
+            "size": 6
+          }
+        ]
+      ]
+    },
+    "uid": "plugin::users-permissions.permission"
+  },
+  "type": "object",
+  "environment": null,
+  "tag": null
+}

--- a/config/sync/core-store.plugin_content_manager_configuration_content_types##plugin##users-permissions.role.json
+++ b/config/sync/core-store.plugin_content_manager_configuration_content_types##plugin##users-permissions.role.json
@@ -1,0 +1,194 @@
+{
+  "key": "plugin_content_manager_configuration_content_types::plugin::users-permissions.role",
+  "value": {
+    "settings": {
+      "bulkable": true,
+      "filterable": true,
+      "searchable": true,
+      "pageSize": 10,
+      "mainField": "name",
+      "defaultSortBy": "name",
+      "defaultSortOrder": "ASC"
+    },
+    "metadatas": {
+      "id": {
+        "edit": {},
+        "list": {
+          "label": "id",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "name": {
+        "edit": {
+          "label": "name",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "name",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "description": {
+        "edit": {
+          "label": "description",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "description",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "type": {
+        "edit": {
+          "label": "type",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "type",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "permissions": {
+        "edit": {
+          "label": "permissions",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true,
+          "mainField": "action"
+        },
+        "list": {
+          "label": "permissions",
+          "searchable": false,
+          "sortable": false
+        }
+      },
+      "users": {
+        "edit": {
+          "label": "users",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true,
+          "mainField": "username"
+        },
+        "list": {
+          "label": "users",
+          "searchable": false,
+          "sortable": false
+        }
+      },
+      "createdAt": {
+        "edit": {
+          "label": "createdAt",
+          "description": "",
+          "placeholder": "",
+          "visible": false,
+          "editable": true
+        },
+        "list": {
+          "label": "createdAt",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "updatedAt": {
+        "edit": {
+          "label": "updatedAt",
+          "description": "",
+          "placeholder": "",
+          "visible": false,
+          "editable": true
+        },
+        "list": {
+          "label": "updatedAt",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "createdBy": {
+        "edit": {
+          "label": "createdBy",
+          "description": "",
+          "placeholder": "",
+          "visible": false,
+          "editable": true,
+          "mainField": "firstname"
+        },
+        "list": {
+          "label": "createdBy",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "updatedBy": {
+        "edit": {
+          "label": "updatedBy",
+          "description": "",
+          "placeholder": "",
+          "visible": false,
+          "editable": true,
+          "mainField": "firstname"
+        },
+        "list": {
+          "label": "updatedBy",
+          "searchable": true,
+          "sortable": true
+        }
+      }
+    },
+    "layouts": {
+      "list": [
+        "id",
+        "name",
+        "description",
+        "type"
+      ],
+      "edit": [
+        [
+          {
+            "name": "name",
+            "size": 6
+          },
+          {
+            "name": "description",
+            "size": 6
+          }
+        ],
+        [
+          {
+            "name": "type",
+            "size": 6
+          },
+          {
+            "name": "permissions",
+            "size": 6
+          }
+        ],
+        [
+          {
+            "name": "users",
+            "size": 6
+          }
+        ]
+      ]
+    },
+    "uid": "plugin::users-permissions.role"
+  },
+  "type": "object",
+  "environment": null,
+  "tag": null
+}

--- a/config/sync/core-store.plugin_content_manager_configuration_content_types##plugin##users-permissions.user.json
+++ b/config/sync/core-store.plugin_content_manager_configuration_content_types##plugin##users-permissions.user.json
@@ -1,0 +1,253 @@
+{
+  "key": "plugin_content_manager_configuration_content_types::plugin::users-permissions.user",
+  "value": {
+    "settings": {
+      "bulkable": true,
+      "filterable": true,
+      "searchable": true,
+      "pageSize": 10,
+      "mainField": "username",
+      "defaultSortBy": "username",
+      "defaultSortOrder": "ASC"
+    },
+    "metadatas": {
+      "id": {
+        "edit": {},
+        "list": {
+          "label": "id",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "username": {
+        "edit": {
+          "label": "username",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "username",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "email": {
+        "edit": {
+          "label": "email",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "email",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "provider": {
+        "edit": {
+          "label": "provider",
+          "description": "",
+          "placeholder": "",
+          "visible": false,
+          "editable": true
+        },
+        "list": {
+          "label": "provider",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "password": {
+        "edit": {
+          "label": "password",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "password",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "resetPasswordToken": {
+        "edit": {
+          "label": "resetPasswordToken",
+          "description": "",
+          "placeholder": "",
+          "visible": false,
+          "editable": true
+        },
+        "list": {
+          "label": "resetPasswordToken",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "confirmationToken": {
+        "edit": {
+          "label": "confirmationToken",
+          "description": "",
+          "placeholder": "",
+          "visible": false,
+          "editable": true
+        },
+        "list": {
+          "label": "confirmationToken",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "confirmed": {
+        "edit": {
+          "label": "confirmed",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "confirmed",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "blocked": {
+        "edit": {
+          "label": "blocked",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "blocked",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "role": {
+        "edit": {
+          "label": "role",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true,
+          "mainField": "name"
+        },
+        "list": {
+          "label": "role",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "createdAt": {
+        "edit": {
+          "label": "createdAt",
+          "description": "",
+          "placeholder": "",
+          "visible": false,
+          "editable": true
+        },
+        "list": {
+          "label": "createdAt",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "updatedAt": {
+        "edit": {
+          "label": "updatedAt",
+          "description": "",
+          "placeholder": "",
+          "visible": false,
+          "editable": true
+        },
+        "list": {
+          "label": "updatedAt",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "createdBy": {
+        "edit": {
+          "label": "createdBy",
+          "description": "",
+          "placeholder": "",
+          "visible": false,
+          "editable": true,
+          "mainField": "firstname"
+        },
+        "list": {
+          "label": "createdBy",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "updatedBy": {
+        "edit": {
+          "label": "updatedBy",
+          "description": "",
+          "placeholder": "",
+          "visible": false,
+          "editable": true,
+          "mainField": "firstname"
+        },
+        "list": {
+          "label": "updatedBy",
+          "searchable": true,
+          "sortable": true
+        }
+      }
+    },
+    "layouts": {
+      "list": [
+        "id",
+        "username",
+        "email",
+        "confirmed"
+      ],
+      "edit": [
+        [
+          {
+            "name": "username",
+            "size": 6
+          },
+          {
+            "name": "email",
+            "size": 6
+          }
+        ],
+        [
+          {
+            "name": "password",
+            "size": 6
+          },
+          {
+            "name": "confirmed",
+            "size": 4
+          }
+        ],
+        [
+          {
+            "name": "blocked",
+            "size": 4
+          },
+          {
+            "name": "role",
+            "size": 6
+          }
+        ]
+      ]
+    },
+    "uid": "plugin::users-permissions.user"
+  },
+  "type": "object",
+  "environment": null,
+  "tag": null
+}

--- a/config/sync/core-store.plugin_i18n_default_locale.json
+++ b/config/sync/core-store.plugin_i18n_default_locale.json
@@ -1,0 +1,7 @@
+{
+  "key": "plugin_i18n_default_locale",
+  "value": "en",
+  "type": "string",
+  "environment": null,
+  "tag": null
+}

--- a/config/sync/core-store.plugin_upload_settings.json
+++ b/config/sync/core-store.plugin_upload_settings.json
@@ -1,0 +1,11 @@
+{
+  "key": "plugin_upload_settings",
+  "value": {
+    "sizeOptimization": true,
+    "responsiveDimensions": true,
+    "autoOrientation": false
+  },
+  "type": "object",
+  "environment": null,
+  "tag": null
+}

--- a/config/sync/core-store.plugin_upload_view_configuration.json
+++ b/config/sync/core-store.plugin_upload_view_configuration.json
@@ -1,0 +1,10 @@
+{
+  "key": "plugin_upload_view_configuration",
+  "value": {
+    "pageSize": 10,
+    "sort": "createdAt:DESC"
+  },
+  "type": "object",
+  "environment": null,
+  "tag": null
+}

--- a/config/sync/core-store.plugin_users-permissions_advanced.json
+++ b/config/sync/core-store.plugin_users-permissions_advanced.json
@@ -1,0 +1,14 @@
+{
+  "key": "plugin_users-permissions_advanced",
+  "value": {
+    "unique_email": true,
+    "allow_register": true,
+    "email_confirmation": false,
+    "email_reset_password": null,
+    "email_confirmation_redirection": null,
+    "default_role": "authenticated"
+  },
+  "type": "object",
+  "environment": null,
+  "tag": null
+}

--- a/config/sync/core-store.plugin_users-permissions_email.json
+++ b/config/sync/core-store.plugin_users-permissions_email.json
@@ -1,0 +1,34 @@
+{
+  "key": "plugin_users-permissions_email",
+  "value": {
+    "reset_password": {
+      "display": "Email.template.reset_password",
+      "icon": "sync",
+      "options": {
+        "from": {
+          "name": "Administration Panel",
+          "email": "no-reply@strapi.io"
+        },
+        "response_email": "",
+        "object": "Reset password",
+        "message": "<p>We heard that you lost your password. Sorry about that!</p>\n\n<p>But don’t worry! You can use the following link to reset your password:</p>\n<p><%= URL %>?code=<%= TOKEN %></p>\n\n<p>Thanks.</p>"
+      }
+    },
+    "email_confirmation": {
+      "display": "Email.template.email_confirmation",
+      "icon": "check-square",
+      "options": {
+        "from": {
+          "name": "Administration Panel",
+          "email": "no-reply@strapi.io"
+        },
+        "response_email": "",
+        "object": "Account confirmation",
+        "message": "<p>Thank you for registering!</p>\n\n<p>You have to confirm your email address. Please click on the link below.</p>\n\n<p><%= URL %>?confirmation=<%= CODE %></p>\n\n<p>Thanks.</p>"
+      }
+    }
+  },
+  "type": "object",
+  "environment": null,
+  "tag": null
+}

--- a/config/sync/i18n-locale.en.json
+++ b/config/sync/i18n-locale.en.json
@@ -1,0 +1,4 @@
+{
+  "name": "English (en)",
+  "code": "en"
+}

--- a/config/sync/user-role.authenticated.json
+++ b/config/sync/user-role.authenticated.json
@@ -1,0 +1,13 @@
+{
+  "name": "Authenticated",
+  "description": "Default role given to authenticated user.",
+  "type": "authenticated",
+  "permissions": [
+    {
+      "action": "plugin::users-permissions.auth.changePassword"
+    },
+    {
+      "action": "plugin::users-permissions.user.me"
+    }
+  ]
+}

--- a/config/sync/user-role.authenticated.json
+++ b/config/sync/user-role.authenticated.json
@@ -4,6 +4,24 @@
   "type": "authenticated",
   "permissions": [
     {
+      "action": "api::content-creator.content-creator.find"
+    },
+    {
+      "action": "api::content-creator.content-creator.findOne"
+    },
+    {
+      "action": "api::event.event.find"
+    },
+    {
+      "action": "api::event.event.findOne"
+    },
+    {
+      "action": "api::project.project.find"
+    },
+    {
+      "action": "api::project.project.findOne"
+    },
+    {
       "action": "plugin::users-permissions.auth.changePassword"
     },
     {

--- a/config/sync/user-role.public.json
+++ b/config/sync/user-role.public.json
@@ -1,0 +1,40 @@
+{
+  "name": "Public",
+  "description": "Default role given to unauthenticated user.",
+  "type": "public",
+  "permissions": [
+    {
+      "action": "api::content-creator.content-creator.find"
+    },
+    {
+      "action": "api::content-creator.content-creator.findOne"
+    },
+    {
+      "action": "api::event.event.find"
+    },
+    {
+      "action": "api::event.event.findOne"
+    },
+    {
+      "action": "plugin::users-permissions.auth.callback"
+    },
+    {
+      "action": "plugin::users-permissions.auth.connect"
+    },
+    {
+      "action": "plugin::users-permissions.auth.emailConfirmation"
+    },
+    {
+      "action": "plugin::users-permissions.auth.forgotPassword"
+    },
+    {
+      "action": "plugin::users-permissions.auth.register"
+    },
+    {
+      "action": "plugin::users-permissions.auth.resetPassword"
+    },
+    {
+      "action": "plugin::users-permissions.auth.sendEmailConfirmation"
+    }
+  ]
+}

--- a/config/sync/user-role.public.json
+++ b/config/sync/user-role.public.json
@@ -16,6 +16,18 @@
       "action": "api::event.event.findOne"
     },
     {
+      "action": "api::pop-up.pop-up.find"
+    },
+    {
+      "action": "api::pop-up.pop-up.findOne"
+    },
+    {
+      "action": "api::project.project.find"
+    },
+    {
+      "action": "api::project.project.findOne"
+    },
+    {
       "action": "plugin::users-permissions.auth.callback"
     },
     {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "my-strapi-project",
+  "name": "arebyte-plugin-backend",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "my-strapi-project",
+      "name": "arebyte-plugin-backend",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
@@ -17,6 +17,7 @@
         "react": "^18.0.0",
         "react-dom": "^18.0.0",
         "react-router-dom": "5.3.4",
+        "strapi-plugin-config-sync": "^1.2.6",
         "styled-components": "5.3.3"
       },
       "devDependencies": {},
@@ -599,6 +600,18 @@
         "@emotion/utils": "^1.4.0",
         "@emotion/weak-memoize": "^0.4.0",
         "stylis": "4.2.0"
+      }
+    },
+    "node_modules/@emotion/css": {
+      "version": "11.13.0",
+      "resolved": "https://registry.npmjs.org/@emotion/css/-/css-11.13.0.tgz",
+      "integrity": "sha512-BUk99ylT+YHl+W/HN7nv1RCTkDYmKKqa1qbvM/qLSQEg61gipuBF5Hptk/2/ERmX2DCv0ccuFGhz9i0KSZOqPg==",
+      "dependencies": {
+        "@emotion/babel-plugin": "^11.12.0",
+        "@emotion/cache": "^11.13.0",
+        "@emotion/serialize": "^1.3.0",
+        "@emotion/sheet": "^1.4.0",
+        "@emotion/utils": "^1.4.0"
       }
     },
     "node_modules/@emotion/hash": {
@@ -6344,6 +6357,11 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow=="
+    },
     "node_modules/clean-css": {
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.3.3.tgz",
@@ -6413,6 +6431,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-table": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.11.tgz",
+      "integrity": "sha512-IqLQi4lO0nIB4tcdTpN4LCB9FI3uqrJZK7RC515EnhZ6qBaglkIgICb1wjeAqpdoOabm1+SuQtkXIPdYC93jhQ==",
+      "dependencies": {
+        "colors": "1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.2.0"
       }
     },
     "node_modules/cli-table3": {
@@ -6570,6 +6599,14 @@
       "version": "2.0.19",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.19.tgz",
       "integrity": "sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ=="
+    },
+    "node_modules/colors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+      "integrity": "sha512-pFGrxThWcWQ2MsAz6RtgeWe4NK2kUE1WfsrvvlctdII745EW9I0yflqhe7++M5LEc7bV2c/9/5zc8sFcpL0Drw==",
+      "engines": {
+        "node": ">=0.1.90"
+      }
     },
     "node_modules/colorspace": {
       "version": "1.1.4",
@@ -7481,6 +7518,14 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
       "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="
+    },
+    "node_modules/diff": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "engines": {
+        "node": ">=0.3.1"
+      }
     },
     "node_modules/dir-glob": {
       "version": "3.0.1",
@@ -9201,6 +9246,85 @@
       "resolved": "https://registry.npmjs.org/getopts/-/getopts-2.3.0.tgz",
       "integrity": "sha512-5eDf9fuSXwxBL6q5HX+dhDj+dslFGWzU5thZ9kNKUkcPtaPdatmUFKwHFrLb/uf/WpA4BHET+AX3Scl56cAjpA=="
     },
+    "node_modules/git-diff": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/git-diff/-/git-diff-2.0.6.tgz",
+      "integrity": "sha512-/Iu4prUrydE3Pb3lCBMbcSNIf81tgGt0W1ZwknnyF62t3tHmtiJTRj0f+1ZIhp3+Rh0ktz1pJVoa7ZXUCskivA==",
+      "dependencies": {
+        "chalk": "^2.3.2",
+        "diff": "^3.5.0",
+        "loglevel": "^1.6.1",
+        "shelljs": "^0.8.1",
+        "shelljs.exec": "^1.1.7"
+      },
+      "engines": {
+        "node": ">= 4.8.0"
+      }
+    },
+    "node_modules/git-diff/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/git-diff/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/git-diff/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/git-diff/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
+    },
+    "node_modules/git-diff/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/git-diff/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/git-diff/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/git-hooks-list": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/git-hooks-list/-/git-hooks-list-3.1.0.tgz",
@@ -10032,6 +10156,14 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
+      }
+    },
+    "node_modules/immutable": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.2.tgz",
+      "integrity": "sha512-15gZoQ38eYjEjxkorfbcgBKBL6R7T459OuK+CpcWt7O3KF4uPCx2tD0uFETlUDIyo+1789crbMhTvQBSR5yBMg==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/import-fresh": {
@@ -11312,6 +11444,18 @@
       "integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==",
       "engines": {
         "node": ">=0.1.90"
+      }
+    },
+    "node_modules/loglevel": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.2.tgz",
+      "integrity": "sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "funding": {
+        "type": "tidelift",
+        "url": "https://tidelift.com/funding/github/npm/loglevel"
       }
     },
     "node_modules/long-timeout": {
@@ -13709,6 +13853,33 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-diff-viewer-continued": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/react-diff-viewer-continued/-/react-diff-viewer-continued-3.2.6.tgz",
+      "integrity": "sha512-GrzyqQnjIMoej+jMjWvtVSsQqhXgzEGqpXlJ2dAGfOk7Q26qcm8Gu6xtI430PBUyZsERe8BJSQf+7VZZo8IBNQ==",
+      "dependencies": {
+        "@emotion/css": "^11.10.5",
+        "classnames": "^2.3.1",
+        "diff": "^5.1.0",
+        "memoize-one": "^6.0.0",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      },
+      "peerDependencies": {
+        "react": "^15.3.0 || ^16.0.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^15.3.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/react-diff-viewer-continued/node_modules/diff": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
+      "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
     "node_modules/react-dnd": {
       "version": "16.0.1",
       "resolved": "https://registry.npmjs.org/react-dnd/-/react-dnd-16.0.1.tgz",
@@ -14232,6 +14403,14 @@
       "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
       "dependencies": {
         "@babel/runtime": "^7.9.2"
+      }
+    },
+    "node_modules/redux-immutable": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/redux-immutable/-/redux-immutable-4.0.0.tgz",
+      "integrity": "sha512-SchSn/DWfGb3oAejd+1hhHx01xUoxY+V7TeK0BKqpkLKiQPVFf7DYzEaKmrEVxsWxielKfSK9/Xq66YyxgR1cg==",
+      "peerDependencies": {
+        "immutable": "^3.8.1 || ^4.0.0-rc.1"
       }
     },
     "node_modules/redux-thunk": {
@@ -15019,6 +15198,89 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/shelljs": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
+      "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
+      "dependencies": {
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
+      },
+      "bin": {
+        "shjs": "bin/shjs"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/shelljs.exec": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/shelljs.exec/-/shelljs.exec-1.1.8.tgz",
+      "integrity": "sha512-vFILCw+lzUtiwBAHV8/Ex8JsFjelFMdhONIsgKNLgTzeRckp2AOYRQtHJE/9LhNvdMmE27AGtzWx0+DHpwIwSw==",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/shelljs/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/shelljs/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/shelljs/node_modules/interpret": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/shelljs/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/shelljs/node_modules/rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==",
+      "dependencies": {
+        "resolve": "^1.1.6"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/side-channel": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
@@ -15580,6 +15842,32 @@
       "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/strapi-plugin-config-sync": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/strapi-plugin-config-sync/-/strapi-plugin-config-sync-1.2.6.tgz",
+      "integrity": "sha512-64D0grtWqdt4+tPqyle3OaJZJBPQUCO3JWHEbDmk8n3WreuWeG/m01uHQr0b41Ykw1tvBE/a66k/cMn2EAxbNw==",
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "cli-table": "^0.3.6",
+        "commander": "^8.3.0",
+        "git-diff": "^2.0.6",
+        "immutable": "^3.8.2",
+        "inquirer": "^8.2.0",
+        "react-diff-viewer-continued": "3.2.6",
+        "redux-immutable": "^4.0.0",
+        "redux-thunk": "^2.3.0"
+      },
+      "bin": {
+        "config-sync": "bin/config-sync"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=6.0.0"
+      },
+      "peerDependencies": {
+        "@strapi/strapi": "^4.0.0"
       }
     },
     "node_modules/stream-chain": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "start": "strapi start",
     "build": "strapi build",
     "strapi": "strapi",
-    "deploy": "strapi deploy"
+    "deploy": "strapi deploy",
+    "cs": "config-sync"
   },
   "dependencies": {
     "@strapi/plugin-cloud": "4.25.11",

--- a/package.json
+++ b/package.json
@@ -10,16 +10,16 @@
     "strapi": "strapi",
     "deploy": "strapi deploy"
   },
-  "devDependencies": {},
   "dependencies": {
-    "@strapi/strapi": "4.25.11",
-    "@strapi/plugin-users-permissions": "4.25.11",
-    "@strapi/plugin-i18n": "4.25.11",
     "@strapi/plugin-cloud": "4.25.11",
+    "@strapi/plugin-i18n": "4.25.11",
+    "@strapi/plugin-users-permissions": "4.25.11",
+    "@strapi/strapi": "4.25.11",
     "better-sqlite3": "8.6.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-router-dom": "5.3.4",
+    "strapi-plugin-config-sync": "^1.2.6",
     "styled-components": "5.3.3"
   },
   "author": {

--- a/src/api/audience-member/content-types/audience-member/schema.json
+++ b/src/api/audience-member/content-types/audience-member/schema.json
@@ -28,12 +28,6 @@
       "default": "12:00",
       "unique": false
     },
-    "followed_artists": {
-      "type": "relation",
-      "relation": "manyToMany",
-      "target": "api::content-creator.content-creator",
-      "inversedBy": "followers"
-    },
     "user_id": {
       "type": "relation",
       "relation": "oneToOne",

--- a/src/api/content-creator/content-types/content-creator/schema.json
+++ b/src/api/content-creator/content-types/content-creator/schema.json
@@ -4,7 +4,7 @@
   "info": {
     "singularName": "content-creator",
     "pluralName": "content-creators",
-    "displayName": "content_creator",
+    "displayName": "Creator Profile",
     "description": ""
   },
   "options": {
@@ -22,16 +22,8 @@
       "target": "api::project.project",
       "mappedBy": "content_creator"
     },
-    "followers": {
-      "type": "relation",
-      "relation": "manyToMany",
-      "target": "api::audience-member.audience-member",
-      "mappedBy": "followed_artists"
-    },
-    "admin_user": {
-      "type": "relation",
-      "relation": "oneToOne",
-      "target": "admin::user"
+    "artist_name": {
+      "type": "string"
     }
   }
 }

--- a/src/api/content-creator/content-types/content-creator/schema.json
+++ b/src/api/content-creator/content-types/content-creator/schema.json
@@ -28,10 +28,10 @@
       "target": "api::audience-member.audience-member",
       "mappedBy": "followed_artists"
     },
-    "user_id": {
+    "admin_user": {
       "type": "relation",
       "relation": "oneToOne",
-      "target": "plugin::users-permissions.user"
+      "target": "admin::user"
     }
   }
 }

--- a/src/api/event/content-types/event/schema.json
+++ b/src/api/event/content-types/event/schema.json
@@ -16,16 +16,19 @@
       "type": "string",
       "required": true
     },
-    "pieces": {
-      "type": "component",
-      "repeatable": true,
-      "component": "piece.piece"
-    },
-    "project": {
+    "in_project": {
       "type": "relation",
       "relation": "manyToOne",
       "target": "api::project.project",
       "inversedBy": "events"
+    },
+    "pop_ups": {
+      "type": "relation",
+      "relation": "oneToMany",
+      "target": "api::pop-up.pop-up"
+    },
+    "event_description": {
+      "type": "blocks"
     }
   }
 }

--- a/src/api/pop-up/content-types/pop-up/schema.json
+++ b/src/api/pop-up/content-types/pop-up/schema.json
@@ -1,0 +1,59 @@
+{
+  "kind": "collectionType",
+  "collectionName": "pop_ups",
+  "info": {
+    "singularName": "pop-up",
+    "pluralName": "pop-ups",
+    "displayName": "pop up",
+    "description": ""
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "title": {
+      "type": "string",
+      "required": true
+    },
+    "media": {
+      "type": "media",
+      "multiple": false,
+      "required": true,
+      "allowedTypes": [
+        "images",
+        "files",
+        "videos",
+        "audios"
+      ]
+    },
+    "description": {
+      "type": "blocks",
+      "required": false
+    },
+    "popup_size": {
+      "type": "enumeration",
+      "enum": [
+        "Original (size of the image)",
+        "Small ",
+        "Medium ",
+        "Large "
+      ],
+      "required": true
+    },
+    "popup_position": {
+      "type": "enumeration",
+      "enum": [
+        "Top Left",
+        "Top center",
+        "Top right",
+        "Center left",
+        "Center",
+        "Center right",
+        "Bottom left",
+        "Bottom center",
+        "Bottom Right"
+      ]
+    }
+  }
+}

--- a/src/api/pop-up/controllers/pop-up.js
+++ b/src/api/pop-up/controllers/pop-up.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * pop-up controller
+ */
+
+const { createCoreController } = require('@strapi/strapi').factories;
+
+module.exports = createCoreController('api::pop-up.pop-up');

--- a/src/api/pop-up/routes/pop-up.js
+++ b/src/api/pop-up/routes/pop-up.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * pop-up router
+ */
+
+const { createCoreRouter } = require('@strapi/strapi').factories;
+
+module.exports = createCoreRouter('api::pop-up.pop-up');

--- a/src/api/pop-up/services/pop-up.js
+++ b/src/api/pop-up/services/pop-up.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * pop-up service
+ */
+
+const { createCoreService } = require('@strapi/strapi').factories;
+
+module.exports = createCoreService('api::pop-up.pop-up');

--- a/src/api/project/content-types/project/schema.json
+++ b/src/api/project/content-types/project/schema.json
@@ -42,7 +42,7 @@
       "type": "relation",
       "relation": "oneToMany",
       "target": "api::event.event",
-      "mappedBy": "project"
+      "mappedBy": "in_project"
     }
   }
 }

--- a/src/extensions/users-permissions/content-types/user/schema.json
+++ b/src/extensions/users-permissions/content-types/user/schema.json
@@ -1,0 +1,69 @@
+{
+  "kind": "collectionType",
+  "collectionName": "up_users",
+  "info": {
+    "name": "user",
+    "description": "",
+    "singularName": "user",
+    "pluralName": "users",
+    "displayName": "User"
+  },
+  "options": {
+    "draftAndPublish": false
+  },
+  "attributes": {
+    "username": {
+      "type": "string",
+      "minLength": 3,
+      "unique": true,
+      "configurable": false,
+      "required": true
+    },
+    "email": {
+      "type": "email",
+      "minLength": 6,
+      "configurable": false,
+      "required": true
+    },
+    "provider": {
+      "type": "string",
+      "configurable": false
+    },
+    "password": {
+      "type": "password",
+      "minLength": 6,
+      "configurable": false,
+      "private": true,
+      "searchable": false
+    },
+    "resetPasswordToken": {
+      "type": "string",
+      "configurable": false,
+      "private": true,
+      "searchable": false
+    },
+    "confirmationToken": {
+      "type": "string",
+      "configurable": false,
+      "private": true,
+      "searchable": false
+    },
+    "confirmed": {
+      "type": "boolean",
+      "default": false,
+      "configurable": false
+    },
+    "blocked": {
+      "type": "boolean",
+      "default": false,
+      "configurable": false
+    },
+    "role": {
+      "type": "relation",
+      "relation": "manyToOne",
+      "target": "plugin::users-permissions.role",
+      "inversedBy": "users",
+      "configurable": false
+    }
+  }
+}

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -590,6 +590,53 @@ export interface PluginContentReleasesReleaseAction
   };
 }
 
+export interface PluginI18NLocale extends Schema.CollectionType {
+  collectionName: 'i18n_locale';
+  info: {
+    singularName: 'locale';
+    pluralName: 'locales';
+    collectionName: 'locales';
+    displayName: 'Locale';
+    description: '';
+  };
+  options: {
+    draftAndPublish: false;
+  };
+  pluginOptions: {
+    'content-manager': {
+      visible: false;
+    };
+    'content-type-builder': {
+      visible: false;
+    };
+  };
+  attributes: {
+    name: Attribute.String &
+      Attribute.SetMinMax<
+        {
+          min: 1;
+          max: 50;
+        },
+        number
+      >;
+    code: Attribute.String & Attribute.Unique;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<
+      'plugin::i18n.locale',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<
+      'plugin::i18n.locale',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+  };
+}
+
 export interface PluginUsersPermissionsPermission
   extends Schema.CollectionType {
   collectionName: 'up_permissions';
@@ -734,53 +781,6 @@ export interface PluginUsersPermissionsUser extends Schema.CollectionType {
       Attribute.Private;
     updatedBy: Attribute.Relation<
       'plugin::users-permissions.user',
-      'oneToOne',
-      'admin::user'
-    > &
-      Attribute.Private;
-  };
-}
-
-export interface PluginI18NLocale extends Schema.CollectionType {
-  collectionName: 'i18n_locale';
-  info: {
-    singularName: 'locale';
-    pluralName: 'locales';
-    collectionName: 'locales';
-    displayName: 'Locale';
-    description: '';
-  };
-  options: {
-    draftAndPublish: false;
-  };
-  pluginOptions: {
-    'content-manager': {
-      visible: false;
-    };
-    'content-type-builder': {
-      visible: false;
-    };
-  };
-  attributes: {
-    name: Attribute.String &
-      Attribute.SetMinMax<
-        {
-          min: 1;
-          max: 50;
-        },
-        number
-      >;
-    code: Attribute.String & Attribute.Unique;
-    createdAt: Attribute.DateTime;
-    updatedAt: Attribute.DateTime;
-    createdBy: Attribute.Relation<
-      'plugin::i18n.locale',
-      'oneToOne',
-      'admin::user'
-    > &
-      Attribute.Private;
-    updatedBy: Attribute.Relation<
-      'plugin::i18n.locale',
       'oneToOne',
       'admin::user'
     > &
@@ -980,10 +980,10 @@ declare module '@strapi/types' {
       'plugin::upload.folder': PluginUploadFolder;
       'plugin::content-releases.release': PluginContentReleasesRelease;
       'plugin::content-releases.release-action': PluginContentReleasesReleaseAction;
+      'plugin::i18n.locale': PluginI18NLocale;
       'plugin::users-permissions.permission': PluginUsersPermissionsPermission;
       'plugin::users-permissions.role': PluginUsersPermissionsRole;
       'plugin::users-permissions.user': PluginUsersPermissionsUser;
-      'plugin::i18n.locale': PluginI18NLocale;
       'api::audience-member.audience-member': ApiAudienceMemberAudienceMember;
       'api::content-creator.content-creator': ApiContentCreatorContentCreator;
       'api::event.event': ApiEventEvent;

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -810,11 +810,6 @@ export interface ApiAudienceMemberAudienceMember extends Schema.CollectionType {
     event_time: Attribute.Time &
       Attribute.Required &
       Attribute.DefaultTo<'12:00'>;
-    followed_artists: Attribute.Relation<
-      'api::audience-member.audience-member',
-      'manyToMany',
-      'api::content-creator.content-creator'
-    >;
     user_id: Attribute.Relation<
       'api::audience-member.audience-member',
       'oneToOne',
@@ -843,7 +838,7 @@ export interface ApiContentCreatorContentCreator extends Schema.CollectionType {
   info: {
     singularName: 'content-creator';
     pluralName: 'content-creators';
-    displayName: 'content_creator';
+    displayName: 'Creator Profile';
     description: '';
   };
   options: {
@@ -856,16 +851,7 @@ export interface ApiContentCreatorContentCreator extends Schema.CollectionType {
       'oneToMany',
       'api::project.project'
     >;
-    followers: Attribute.Relation<
-      'api::content-creator.content-creator',
-      'manyToMany',
-      'api::audience-member.audience-member'
-    >;
-    admin_user: Attribute.Relation<
-      'api::content-creator.content-creator',
-      'oneToOne',
-      'admin::user'
-    >;
+    artist_name: Attribute.String;
     createdAt: Attribute.DateTime;
     updatedAt: Attribute.DateTime;
     publishedAt: Attribute.DateTime;

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -742,7 +742,6 @@ export interface PluginUsersPermissionsUser extends Schema.CollectionType {
   };
   options: {
     draftAndPublish: false;
-    timestamps: true;
   };
   attributes: {
     username: Attribute.String &
@@ -862,10 +861,10 @@ export interface ApiContentCreatorContentCreator extends Schema.CollectionType {
       'manyToMany',
       'api::audience-member.audience-member'
     >;
-    user_id: Attribute.Relation<
+    admin_user: Attribute.Relation<
       'api::content-creator.content-creator',
       'oneToOne',
-      'plugin::users-permissions.user'
+      'admin::user'
     >;
     createdAt: Attribute.DateTime;
     updatedAt: Attribute.DateTime;
@@ -898,12 +897,17 @@ export interface ApiEventEvent extends Schema.CollectionType {
   };
   attributes: {
     title: Attribute.String & Attribute.Required;
-    pieces: Attribute.Component<'piece.piece', true>;
-    project: Attribute.Relation<
+    in_project: Attribute.Relation<
       'api::event.event',
       'manyToOne',
       'api::project.project'
     >;
+    pop_ups: Attribute.Relation<
+      'api::event.event',
+      'oneToMany',
+      'api::pop-up.pop-up'
+    >;
+    event_description: Attribute.Blocks;
     createdAt: Attribute.DateTime;
     updatedAt: Attribute.DateTime;
     publishedAt: Attribute.DateTime;
@@ -915,6 +919,57 @@ export interface ApiEventEvent extends Schema.CollectionType {
       Attribute.Private;
     updatedBy: Attribute.Relation<
       'api::event.event',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+  };
+}
+
+export interface ApiPopUpPopUp extends Schema.CollectionType {
+  collectionName: 'pop_ups';
+  info: {
+    singularName: 'pop-up';
+    pluralName: 'pop-ups';
+    displayName: 'pop up';
+    description: '';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    title: Attribute.String & Attribute.Required;
+    media: Attribute.Media<'images' | 'files' | 'videos' | 'audios'> &
+      Attribute.Required;
+    description: Attribute.Blocks;
+    popup_size: Attribute.Enumeration<
+      ['Original (size of the image)', 'Small ', 'Medium ', 'Large ']
+    > &
+      Attribute.Required;
+    popup_position: Attribute.Enumeration<
+      [
+        'Top Left',
+        'Top center',
+        'Top right',
+        'Center left',
+        'Center',
+        'Center right',
+        'Bottom left',
+        'Bottom center',
+        'Bottom Right'
+      ]
+    >;
+    createdAt: Attribute.DateTime;
+    updatedAt: Attribute.DateTime;
+    publishedAt: Attribute.DateTime;
+    createdBy: Attribute.Relation<
+      'api::pop-up.pop-up',
+      'oneToOne',
+      'admin::user'
+    > &
+      Attribute.Private;
+    updatedBy: Attribute.Relation<
+      'api::pop-up.pop-up',
       'oneToOne',
       'admin::user'
     > &
@@ -987,6 +1042,7 @@ declare module '@strapi/types' {
       'api::audience-member.audience-member': ApiAudienceMemberAudienceMember;
       'api::content-creator.content-creator': ApiContentCreatorContentCreator;
       'api::event.event': ApiEventEvent;
+      'api::pop-up.pop-up': ApiPopUpPopUp;
       'api::project.project': ApiProjectProject;
     }
   }


### PR DESCRIPTION
# Description

**Closes #5**  

This PR lays out the first draft of the content types and permission and attempts to refine the flow for the content creators use of the CMS. 
It:
- Adds to types for project, events and popups
- Restricts permission so that content creator will only see the content that they have created
- add a creator profile content type and a joining table for all these content types.

### Changes to Documentation

Updates README with Plugin information
