### PR TITLE
test: extended tests to cover login flow

### DIFF
--- a/bruno/unauthenticated/login.bru
+++ b/bruno/unauthenticated/login.bru
@@ -1,0 +1,22 @@
+meta {
+  name: login
+  type: http
+  seq: 4
+}
+
+post {
+  url: {{host}}/api/auth/local/
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+}
+
+body:json {
+  {
+    "identifier": "artone@test.com",
+    "password": "Art1Test"
+  }
+}

--- a/config/plugins.js
+++ b/config/plugins.js
@@ -1,16 +1,23 @@
 module.exports = ({ env }) => ({
   // ..
- 'transformer': {
+  transformer: {
     enabled: true,
     config: {
       responseTransforms: {
         removeAttributesKey: true,
         removeDataKey: true,
       },
-      requestTransforms : {
-        wrapBodyWithDataKey: true
+      requestTransforms: {
+        wrapBodyWithDataKey: true,
       },
-    }
+    },
+  },
+  "user-permissions": {
+    config: {
+      jwt: {
+        expiresIn: "128d",
+      },
+    },
   },
   // ..
 });


### PR DESCRIPTION
# Description

**Relates to 33 in the frontend**  

Sets the duration of a token to 6 months and adds a new bruno test to verify the login api call.

### Files changed

- `config/plugins.js` - edits the default duration of all our `jwt`s to be 6 months

### UI changes

n/a

### Changes to Documentation

none needed

# Tests

- `bruno/unauthenticated/login.bru`
