### PR TITLE
feat: extend user type to include birth_date and location

### DIFF
--- a/src/extensions/users-permissions/content-types/user/schema.json
+++ b/src/extensions/users-permissions/content-types/user/schema.json
@@ -70,6 +70,14 @@
       "relation": "oneToOne",
       "target": "api::audience-member.audience-member",
       "mappedBy": "users_permissions_user"
+    },
+    "birth_date": {
+      "type": "date",
+      "required": true
+    },
+    "location": {
+      "type": "string",
+      "required": true
     }
   }
 }

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -775,6 +775,8 @@ export interface PluginUsersPermissionsUser extends Schema.CollectionType {
       'oneToOne',
       'api::audience-member.audience-member'
     >;
+    birth_date: Attribute.Date & Attribute.Required;
+    location: Attribute.String & Attribute.Required;
     createdAt: Attribute.DateTime;
     updatedAt: Attribute.DateTime;
     createdBy: Attribute.Relation<


### PR DESCRIPTION
# Description

Relates to issue 55 on the frontend

Sets `birth_date` and `location` in the `user` content-type.

You will need to set these values in your users and re-select an audience_member record for each one of them before you try to log in on the extension again otherwise the whole thing will break

### Files changed

n/a

### UI changes

n/a

### Changes to Documentation

n/a

# Tests

Include a description of any tests added - if none have been added explain why.
