### PR TITLE
fix: update user type to make birth_date and location optional fields

### DIFF
--- a/src/extensions/users-permissions/content-types/user/schema.json
+++ b/src/extensions/users-permissions/content-types/user/schema.json
@@ -73,11 +73,11 @@
     },
     "birth_date": {
       "type": "date",
-      "required": true
+      "required": false
     },
     "location": {
       "type": "string",
-      "required": true
+      "required": false
     }
   }
 }

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -775,8 +775,8 @@ export interface PluginUsersPermissionsUser extends Schema.CollectionType {
       'oneToOne',
       'api::audience-member.audience-member'
     >;
-    birth_date: Attribute.Date & Attribute.Required;
-    location: Attribute.String & Attribute.Required;
+    birth_date: Attribute.Date;
+    location: Attribute.String;
     createdAt: Attribute.DateTime;
     updatedAt: Attribute.DateTime;
     createdBy: Attribute.Relation<


### PR DESCRIPTION
# Description

Relates to issue 55 on the frontend

Fixed the content type user to make the `birth_date` and `location` fields optional

### Files changed

As above

### UI changes

n/a

### Changes to Documentation

n/a

# Tests

n/a - behaviour unchanged